### PR TITLE
Add JSON-based asset preloader for pirates game

### DIFF
--- a/pirates/assets.js
+++ b/pirates/assets.js
@@ -1,53 +1,35 @@
 (function(global){
-  /**
-   * Load an image for the city icon.
-   * @param {string} url - URL of the city icon image.
-   * @returns {Promise<HTMLImageElement|null>} Resolves with the loaded image or null on failure.
-   */
-  function loadCityImage(url){
-    return new Promise((resolve) => {
+  const assets = {};
+  global.assets = assets;
+
+  async function loadAssets(){
+    const response = await fetch('assets.json');
+    const data = await response.json();
+    await loadNested(data, assets);
+    return assets;
+  }
+
+  async function loadNested(src, target){
+    const entries = Object.entries(src);
+    await Promise.all(entries.map(async ([key, value]) => {
+      if (typeof value === 'string'){
+        target[key] = await loadImage(value);
+      } else if (typeof value === 'object' && value !== null){
+        const obj = {};
+        target[key] = obj;
+        await loadNested(value, obj);
+      }
+    }));
+  }
+
+  function loadImage(url){
+    return new Promise(resolve => {
       const img = new Image();
       img.onload = () => resolve(img);
-      img.onerror = () => {
-        console.warn('Failed to load city image:', url);
-        resolve(null); // Fallback handled in rendering.
-      };
+      img.onerror = () => { console.warn('Failed to load image:', url); resolve(null); };
       img.src = url;
     });
   }
 
-  /**
-   * Load ship sprites keyed by ship type and nation.
-   * @param {Object} urlMap - Nested map of ship types to nation URLs.
-   * @returns {Promise<Object>} Resolves with a similarly structured map of images.
-   */
-  async function loadShipSprites(urlMap){
-    const spriteMap = {};
-    const promises = [];
-    for (const [type, nations] of Object.entries(urlMap)){
-      spriteMap[type] = {};
-      for (const [nation, url] of Object.entries(nations)){
-        const img = new Image();
-        const p = new Promise(resolve => {
-          img.onload = () => resolve({type, nation, img});
-          img.onerror = () => {
-            console.warn('Failed to load ship sprite:', type, nation, url);
-            resolve({type, nation, img: null});
-          };
-        });
-        img.src = url;
-        promises.push(p);
-      }
-    }
-    const results = await Promise.all(promises);
-    results.forEach(({type, nation, img}) => {
-      if (!spriteMap[type]) spriteMap[type] = {};
-      spriteMap[type][nation] = img;
-    });
-    return spriteMap;
-  }
-
-  // Expose globally so inline scripts can access it.
-  global.loadCityImage = loadCityImage;
-  global.loadShipSprites = loadShipSprites;
+  global.loadAssets = loadAssets;
 })(window);

--- a/pirates/assets.json
+++ b/pirates/assets.json
@@ -1,0 +1,24 @@
+{
+  "city": "https://via.placeholder.com/16x16?text=C",
+  "island": "https://via.placeholder.com/64x64?text=I",
+  "ship": {
+    "Sloop": {
+      "Netherlands": "https://via.placeholder.com/64?text=Sloop+NL",
+      "Spain": "https://via.placeholder.com/64?text=Sloop+SP",
+      "France": "https://via.placeholder.com/64?text=Sloop+FR",
+      "England": "https://via.placeholder.com/64?text=Sloop+EN"
+    },
+    "Brig": {
+      "Netherlands": "https://via.placeholder.com/64?text=Brig+NL",
+      "Spain": "https://via.placeholder.com/64?text=Brig+SP",
+      "France": "https://via.placeholder.com/64?text=Brig+FR",
+      "England": "https://via.placeholder.com/64?text=Brig+EN"
+    },
+    "Galleon": {
+      "Netherlands": "https://via.placeholder.com/64?text=Gal+NL",
+      "Spain": "https://via.placeholder.com/64?text=Gal+SP",
+      "France": "https://via.placeholder.com/64?text=Gal+FR",
+      "England": "https://via.placeholder.com/64?text=Gal+EN"
+    }
+  }
+}

--- a/pirates/index.html
+++ b/pirates/index.html
@@ -162,33 +162,7 @@
       const governorMenuDiv = document.getElementById('governorMenu');
       const upgradeMenuDiv = document.getElementById('upgradeMenu');
 
-      const CITY_ICON_URL = 'city.png';
       const CITY_ICON_SIZE = 16;
-      let cityImg = null;
-      loadCityImage(CITY_ICON_URL).then(img => cityImg = img);
-
-      const SHIP_SPRITE_URLS = {
-        Sloop: {
-          Netherlands: 'https://example.com/sloop_netherlands.png',
-          Spain: 'https://example.com/sloop_spain.png',
-          France: 'https://example.com/sloop_france.png',
-          England: 'https://example.com/sloop_england.png'
-        },
-        Brig: {
-          Netherlands: 'https://example.com/brig_netherlands.png',
-          Spain: 'https://example.com/brig_spain.png',
-          France: 'https://example.com/brig_france.png',
-          England: 'https://example.com/brig_england.png'
-        },
-        Galleon: {
-          Netherlands: 'https://example.com/galleon_netherlands.png',
-          Spain: 'https://example.com/galleon_spain.png',
-          France: 'https://example.com/galleon_france.png',
-          England: 'https://example.com/galleon_england.png'
-        }
-      };
-      let shipSprites = {};
-      loadShipSprites(SHIP_SPRITE_URLS).then(map => shipSprites = map);
 
       const BASE_SPRITE_SIZE = 32;
       const SPRITE_HD_SCALE = 2;
@@ -199,7 +173,7 @@
         return { w: size, h: size };
       }
       function getShipSprite(type, nation){
-        return shipSprites[type] ? shipSprites[type][nation] : null;
+        return assets.ship && assets.ship[type] ? assets.ship[type][nation] : null;
       }
 
       let lastTime = 0;
@@ -638,9 +612,9 @@
         draw(ctx, offsetX, offsetY) {
           const width = CITY_ICON_SIZE;
           const height = CITY_ICON_SIZE;
-          if (cityImg) {
+          if (assets.city) {
             ctx.drawImage(
-              cityImg,
+              assets.city,
               this.x - offsetX - width / 2,
               this.y - offsetY - height / 2,
               width,
@@ -1705,7 +1679,8 @@
     /***********************
      * Initialization & Loop Start
      ***********************/
-    function initGame() {
+    async function initGame() {
+      await loadAssets();
       initRelationships();
       initReputation();
       generateIslands();
@@ -1714,7 +1689,7 @@
       spawnPlayerShip();
       requestAnimationFrame(gameLoop);
     }
-    
+
     initGame();
     
     // Generate a new quest every 60 seconds.


### PR DESCRIPTION
## Summary
- Add `pirates/assets.json` mapping ships, cities, and islands to sprite URLs
- Implement generic asset preloader in `assets.js`
- Await asset loading in `initGame` and draw cities using loaded assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b342d8f110832f8d92a4e0a3cb3851