### PR TITLE
Add terrain tile assets with loading fallback

### DIFF
--- a/pirates/assets.js
+++ b/pirates/assets.js
@@ -9,24 +9,37 @@
     return assets;
   }
 
-  async function loadNested(src, target){
+  async function loadNested(src, target, path = []){
     const entries = Object.entries(src);
     await Promise.all(entries.map(async ([key, value]) => {
       if (typeof value === 'string'){
-        target[key] = await loadImage(value);
+        const isTile = path[0] === 'tiles';
+        target[key] = await loadImage(value, isTile);
       } else if (typeof value === 'object' && value !== null){
         const obj = {};
         target[key] = obj;
-        await loadNested(value, obj);
+        await loadNested(value, obj, path.concat(key));
       }
     }));
   }
 
-  function loadImage(url){
+  function loadImage(url, isTile = false){
     return new Promise(resolve => {
       const img = new Image();
       img.onload = () => resolve(img);
-      img.onerror = () => { console.warn('Failed to load image:', url); resolve(null); };
+      img.onerror = () => {
+        console.warn('Failed to load image:', url);
+        if (isTile){
+          const canvas = document.createElement('canvas');
+          canvas.width = canvas.height = 16;
+          const ctx = canvas.getContext('2d');
+          ctx.fillStyle = '#f0f';
+          ctx.fillRect(0, 0, 16, 16);
+          resolve(canvas);
+        } else {
+          resolve(null);
+        }
+      };
       img.src = url;
     });
   }

--- a/pirates/assets.json
+++ b/pirates/assets.json
@@ -1,6 +1,10 @@
 {
   "city": "https://via.placeholder.com/16x16?text=C",
   "island": "https://via.placeholder.com/64x64?text=I",
+  "tiles": {
+    "water": "https://via.placeholder.com/16x16?text=W",
+    "land": "https://via.placeholder.com/16x16?text=L"
+  },
   "ship": {
     "Sloop": {
       "Netherlands": "https://via.placeholder.com/64?text=Sloop+NL",


### PR DESCRIPTION
## Summary
- add water and land tile URLs in `assets.json`
- ensure `loadAssets` loads nested tile images and exposes them under `assets.tiles`
- add magenta canvas placeholder when tile images fail to load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1d57900832fa15ce38e67273773