### PR TITLE
feat: use 64px tiles

### DIFF
--- a/pirates/assets.json
+++ b/pirates/assets.json
@@ -2,11 +2,11 @@
   "city": "https://via.placeholder.com/16x16?text=C",
   "island": "https://via.placeholder.com/64x64?text=I",
   "tiles": {
-    "water": "https://via.placeholder.com/16x16?text=W",
-    "land": "https://via.placeholder.com/16x16?text=L",
-    "village": "https://via.placeholder.com/16x16?text=V",
-    "coast": "https://via.placeholder.com/16x16?text=C",
-    "hill": "https://via.placeholder.com/16x16?text=H"
+    "water": "https://via.placeholder.com/64x64?text=W",
+    "land": "https://via.placeholder.com/64x64?text=L",
+    "village": "https://via.placeholder.com/64x64?text=V",
+    "coast": "https://via.placeholder.com/64x64?text=C",
+    "hill": "https://via.placeholder.com/64x64?text=H"
   },
   "ship": {
     "Sloop": {

--- a/pirates/index.html
+++ b/pirates/index.html
@@ -251,14 +251,14 @@
     let quests = []; // Global quest log.
 
     // Navigation grid for AI pathfinding
-    const gridSize = 80;
+    const gridSize = 64;
     const gridCols = Math.floor(worldWidth / gridSize);
     const gridRows = Math.floor(worldHeight / gridSize);
     const Terrain = { WATER: 0, LAND: 1, VILLAGE: 2, COAST: 3, HILL: 4 };
     let tiles = Array.from({ length: gridRows }, () => Array(gridCols).fill(Terrain.WATER));
 
     const tileWidth = gridSize;
-    const tileHeight = gridSize / 2;
+    const tileHeight = gridSize;
 
     function worldToIso(x, y) {
       return { x: (x - y) / 2, y: (x + y) / 4 };


### PR DESCRIPTION
## Summary
- shrink grid to 64px and render tiles as 64x64 squares
- use 64x64 placeholder images for all terrain tiles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -L -o /tmp/tile.png https://via.placeholder.com/64x64?text=W` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b3db703bcc832fb703d3e56a2f393c