### PR TITLE
docs: add local development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,29 @@ Sharing games generated via language models
 
 This project was started as a test if a full functioning game can be created via simple chat bot prompts. 
 
-Every folder contain a game. The objective to have single file, browser games. But, happy to extend it as far we come. 
+Every folder contain a game. The objective to have single file, browser games. But, happy to extend it as far we come.
 
 Note: It is by far not production ready and is only used for evaluation purposes. No warranty and liability is given. Private person targeting no commercial benefits spend spere time.
+
+## Local development
+
+Opening `index.html` through a `file://` URL can block `fetch` requests in many browsers. Run a small web server instead, which will provide permissive CORS headers.
+
+### Python
+
+```sh
+python3 - <<'PY'
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+class Handler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        super().end_headers()
+ThreadingHTTPServer(("localhost", 8000), Handler).serve_forever()
+PY
+```
+
+### Node.js
+
+```sh
+npx http-server . -p 8000 --cors
+```


### PR DESCRIPTION
## Summary
- explain why opening `index.html` via `file://` can block `fetch`
- document python and node commands for running a CORS-enabled server

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3edfa0700832fa72a081ce39de620