### PR TITLE
Add Node.js server without CORS headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ PY
 ```sh
 npx http-server . -p 8000 --cors
 ```
+
+### Node.js (CORS disabled)
+
+For debugging scenarios where cross-origin requests should be blocked, a small
+Node server is included. It serves files without adding any
+`Access-Control-Allow-Origin` headers.
+
+```sh
+node server.js
+```

--- a/server.js
+++ b/server.js
@@ -1,0 +1,40 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 8000;
+
+const server = http.createServer((req, res) => {
+  const requestedPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(process.cwd(), requestedPath);
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not Found');
+      return;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const mimeTypes = {
+      '.html': 'text/html',
+      '.js': 'text/javascript',
+      '.css': 'text/css',
+      '.json': 'application/json',
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.gif': 'image/gif',
+      '.svg': 'image/svg+xml',
+      '.wav': 'audio/wav'
+    };
+
+    const contentType = mimeTypes[ext] || 'application/octet-stream';
+    // Deliberately omit Access-Control-Allow-Origin to disable CORS
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- provide a basic Node HTTP server that omits `Access-Control-Allow-Origin` headers
- document how to run the new server for CORS-disabled debugging

## Testing
- `node server.js & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68b3f568d518832fa3a7f2c8cc30d276