### PR TITLE
Increase tile size and map dimensions

### DIFF
--- a/pirates/index.html
+++ b/pirates/index.html
@@ -158,7 +158,7 @@
     /***********************
      * Global Game Settings
      ***********************/
-    const worldWidth = 2400, worldHeight = 1600;
+    const worldWidth = 4800, worldHeight = 3200;
     const CSS_WIDTH = 800, CSS_HEIGHT = 600;
     const canvas = document.getElementById('gameCanvas');
     const dpr = window.devicePixelRatio || 1;
@@ -251,7 +251,7 @@
     let quests = []; // Global quest log.
 
     // Navigation grid for AI pathfinding
-    const gridSize = 64;
+    const gridSize = 128;
     const gridCols = Math.floor(worldWidth / gridSize);
     const gridRows = Math.floor(worldHeight / gridSize);
     const Terrain = { WATER: 0, LAND: 1, VILLAGE: 2, COAST: 3, HILL: 4 };


### PR DESCRIPTION
## Summary
- expand the pirate game's world to 4800×3200
- enlarge navigation tiles to 128×128 for a larger map

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f8f067b4832fa5508345b9d60415