### PR TITLE
Use relative asset paths in Pirates

### DIFF
--- a/pirates/assets.js
+++ b/pirates/assets.js
@@ -3,7 +3,7 @@
   global.assets = assets;
 
   async function loadAssets(){
-    const response = await fetch('http://localhost:8000/pirates/assets.json');
+    const response = await fetch('/pirates/assets.json');
     const data = await response.json();
     await loadNested(data, assets);
     return assets;

--- a/pirates/assets.json
+++ b/pirates/assets.json
@@ -1,31 +1,31 @@
 {
-  "city": "http://localhost:8000/pirates/assets/villageTB128.png",
-  "island": "http://localhost:8000/pirates/assets/grassTB128.png",
+  "city": "assets/villageTB128.png",
+  "island": "assets/grassTB128.png",
   "tiles": {
-    "water": "http://localhost:8000/pirates/assets/seaTB128.png",
-    "land": "http://localhost:8000/pirates/assets/grassTB128.png",
-    "village": "http://localhost:8000/pirates/assets/villageTB128.png",
-    "coast": "http://localhost:8000/pirates/assets/grassTB128.png",
-    "hill": "http://localhost:8000/pirates/assets/hillTB128.png"
+    "water": "assets/seaTB128.png",
+    "land": "assets/grassTB128.png",
+    "village": "assets/villageTB128.png",
+    "coast": "assets/grassTB128.png",
+    "hill": "assets/hillTB128.png"
   },
   "ship": {
     "Sloop": {
-      "Netherlands": "http://localhost:8000/pirates/assets/slopTB128.png",
-      "Spain": "http://localhost:8000/pirates/assets/slopTB128.png",
-      "France": "http://localhost:8000/pirates/assets/slopTB128.png",
-      "England": "http://localhost:8000/pirates/assets/slopTB128.png"
+      "Netherlands": "assets/slopTB128.png",
+      "Spain": "assets/slopTB128.png",
+      "France": "assets/slopTB128.png",
+      "England": "assets/slopTB128.png"
     },
     "Brig": {
-      "Netherlands":  "http://localhost:8000/pirates/assets/brigTB128.png",
-      "Spain": "http://localhost:8000/pirates/assets/brigTB128.png",
-      "France": "http://localhost:8000/pirates/assets/brigTB128.png",
-      "England": "http://localhost:8000/pirates/assets/brigTB128.png"
+      "Netherlands":  "assets/brigTB128.png",
+      "Spain": "assets/brigTB128.png",
+      "France": "assets/brigTB128.png",
+      "England": "assets/brigTB128.png"
     },
     "Galleon": {
-      "Netherlands": "http://localhost:8000/pirates/assets/galleonTB128.png",
-      "Spain": "http://localhost:8000/pirates/assets/galleonTB128.png",
-      "France": "http://localhost:8000/pirates/assets/galleonTB128.png",
-      "England": "http://localhost:8000/pirates/assets/galleonTB128.png"
+      "Netherlands": "assets/galleonTB128.png",
+      "Spain": "assets/galleonTB128.png",
+      "France": "assets/galleonTB128.png",
+      "England": "assets/galleonTB128.png"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Load `pirates/assets.json` using a relative fetch URL
- Strip hostnames from `pirates/assets.json` so assets reference relative paths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fd8f0618832f9108c1c413c9d57c