### PR TITLE
fix: remove duplicate game loop

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -1749,14 +1749,3 @@ addCard('https://via.placeholder.com/100x150?text=2');
 // Generate a new quest every 60 seconds.
 setInterval(generateRandomQuest, 60000);
 
-/***********************
- * Main Game Loop
- ***********************/
-function gameLoop(timestamp) {
-  const dt = (timestamp - lastTime) / 1000;
-  lastTime = timestamp;
-  update(dt);
-  draw();
-  requestAnimationFrame(gameLoop);
-}
-  


### PR DESCRIPTION
## Summary
- remove duplicate gameLoop function definition in pirates/main.js
- leave single game loop defined earlier

## Testing
- `node --check pirates/main.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b402310708832f8e50318f29dd6a87