### PR TITLE
Use gridSize for tile placeholder

### DIFF
--- a/pirates/assets.js
+++ b/pirates/assets.js
@@ -1,6 +1,8 @@
 export const assets = {};
+let gridSize = 16;
 
-export async function loadAssets(){
+export async function loadAssets(tileSize){
+  if (typeof tileSize === 'number') gridSize = tileSize;
   try {
     const response = await fetch('/pirates/assets.json');
     const data = await response.json();
@@ -34,10 +36,10 @@ function loadImage(url, isTile = false){
       console.warn('Failed to load image:', url);
       if (isTile){
         const canvas = document.createElement('canvas');
-        canvas.width = canvas.height = 16;
+        canvas.width = canvas.height = gridSize;
         const ctx = canvas.getContext('2d');
         ctx.fillStyle = '#f0f';
-        ctx.fillRect(0, 0, 16, 16);
+        ctx.fillRect(0, 0, gridSize, gridSize);
         resolve(canvas);
       } else {
         resolve(null);

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -1736,7 +1736,7 @@ function loadGame() {
 async function initGame() {
   let loadedAssets = {};
   try {
-    loadedAssets = await loadAssets();
+    loadedAssets = await loadAssets(gridSize);
     if (!loadedAssets || Object.keys(loadedAssets).length === 0) {
       console.warn("Starting game with empty asset map.");
     }


### PR DESCRIPTION
## Summary
- allow asset loader to take tile size and use it for placeholder canvas
- pass gridSize when loading assets

## Testing
- `npm test` (fails: no package.json)
- `node --check pirates/assets.js`
- `node --check pirates/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68b406241cc4832f83d276c505d06536