### PR TITLE
Add seed support for deterministic world generation

### DIFF
--- a/pirates/index.html
+++ b/pirates/index.html
@@ -144,6 +144,11 @@
     S: Save game<br>
     L: Load game
   </div>
+  <!-- Seed controls to allow starting world with a specific seed -->
+  <div id="seedControls" style="position:absolute; top:590px; right:10px; background:rgba(0,0,0,0.7); color:#fff; padding:5px;">
+    Seed: <input id="seedInput" type="number" style="width:80px;">
+    <button onclick="startGame(parseFloat(document.getElementById('seedInput').value))">Start</button>
+  </div>
   <!-- Log console -->
   <div id="log"></div>
   <!-- Trade Menu (shown when trading) -->


### PR DESCRIPTION
## Summary
- Allow world generation functions to accept a seed and expose global `startGame` to set it
- Provide UI controls to input a seed before starting
- Persist seed in save data and regenerate islands on load

## Testing
- `node --check pirates/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68b40af74f78832f9b1d09e8cbec7402