### PR TITLE
Auto-start Pirates game on page load

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -1810,3 +1810,6 @@ function startGame(seed) {
 // Expose startGame globally so HTML UI can trigger it.
 window.startGame = startGame;
 
+// Automatically start the game when the page loads.
+window.addEventListener('load', () => startGame());
+


### PR DESCRIPTION
## Summary
- Automatically launch Pirates game when the page loads

## Testing
- `node --check pirates/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b40d7f8790832fae755d9273425e74