### PR TITLE
refactor: use ES module imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "llmgames",
   "version": "1.0.0",
   "description": "Sharing games generated via language models",
-  "main": "server.js",
   "scripts": {
     "test": "echo 'No tests'",
     "start": "node server.js"
@@ -10,7 +9,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "mitt": "^3.0.0",
     "simplex-noise": "^4.0.0"

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
-const http = require('http');
-const fs = require('fs');
-const path = require('path');
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
 
 const port = process.env.PORT || 8000;
 


### PR DESCRIPTION
## Summary
- migrate server.js from CommonJS to ES module imports
- drop unnecessary `main` field and set package type to module

## Testing
- `node server.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b416ae2224832fb6a71383e81aa1f6