### PR TITLE
feat: add ship rotation and controls

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -3,13 +3,22 @@ export class Ship {
     this.x = x;
     this.y = y;
     this.nation = nation;
-    this.speed = 1;
+    this.speed = 0;
+    this.angle = 0;
+    this.turnSpeed = 0.05;
+  }
+
+  rotate(direction) {
+    this.angle += this.turnSpeed * direction;
+  }
+
+  forward(dt) {
+    this.x += Math.cos(this.angle) * this.speed * dt;
+    this.y += Math.sin(this.angle) * this.speed * dt;
   }
 
   update(dt) {
-    // Simple drift to show movement
-    this.x += Math.cos(0) * this.speed * dt;
-    this.y += Math.sin(0) * this.speed * dt;
+    this.forward(dt);
   }
 
   draw(ctx) {

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -27,6 +27,15 @@ initMinimap();
 initLog(bus);
 
 let tiles, player, cities;
+const keys = {};
+
+window.addEventListener('keydown', e => {
+  keys[e.key] = true;
+});
+
+window.addEventListener('keyup', e => {
+  keys[e.key] = false;
+});
 
 function setup(seed=Math.random()) {
   const result = generateWorld(worldWidth, worldHeight, gridSize, seed);
@@ -46,6 +55,10 @@ function loop(timestamp) {
   ctx.clearRect(0, 0, CSS_WIDTH, CSS_HEIGHT);
   drawWorld(ctx, tiles, gridSize, assets);
   cities.forEach(c => c.draw(ctx));
+  if (keys['ArrowLeft']) player.rotate(-1);
+  if (keys['ArrowRight']) player.rotate(1);
+  if (keys['ArrowUp']) player.speed = Math.min(player.speed + 0.1, 5);
+  if (keys['ArrowDown']) player.speed = Math.max(player.speed - 0.1, 0);
   player.update(1); // simplistic update
   player.draw(ctx);
   updateHUD(player);


### PR DESCRIPTION
## Summary
- add angle and turn speed to Ship with rotate/forward mechanics
- add keyboard input to steer ship and adjust throttle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4217fe99c832fa3f0e8da00676fa3