### PR TITLE
Prevent ships from sailing onto land

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -1,4 +1,5 @@
 import { assets } from '../assets.js';
+import { Terrain } from '../world.js';
 
 export class Ship {
   constructor(x, y, nation = 'Pirate') {
@@ -15,12 +16,33 @@ export class Ship {
   }
 
   forward(dt) {
-    this.x += Math.cos(this.angle) * this.speed * dt;
-    this.y += Math.sin(this.angle) * this.speed * dt;
+    return {
+      x: Math.cos(this.angle) * this.speed * dt,
+      y: Math.sin(this.angle) * this.speed * dt
+    };
   }
 
-  update(dt) {
-    this.forward(dt);
+  update(dt, tiles, gridSize) {
+    const { x: dx, y: dy } = this.forward(dt);
+    let newX = this.x + dx;
+    let newY = this.y + dy;
+
+    if (tiles && gridSize) {
+      const tile = tileAt(tiles, newX, newY, gridSize);
+      if (tile === Terrain.LAND || tile === Terrain.COAST) {
+        const tileX = tileAt(tiles, this.x + dx, this.y, gridSize);
+        const tileY = tileAt(tiles, this.x, this.y + dy, gridSize);
+        if (tileX !== Terrain.LAND && tileX !== Terrain.COAST) {
+          this.x += dx;
+        } else if (tileY !== Terrain.LAND && tileY !== Terrain.COAST) {
+          this.y += dy;
+        }
+        return;
+      }
+    }
+
+    this.x = newX;
+    this.y = newY;
   }
 
   draw(ctx) {
@@ -36,4 +58,13 @@ export class Ship {
       ctx.fillRect(this.x - 5, this.y - 5, 10, 10);
     }
   }
+}
+
+function tileAt(tiles, x, y, gridSize) {
+  const row = Math.floor(y / gridSize);
+  const col = Math.floor(x / gridSize);
+  if (row < 0 || row >= tiles.length || col < 0 || col >= tiles[0].length) {
+    return Terrain.LAND;
+  }
+  return tiles[row][col];
 }

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -59,7 +59,7 @@ function loop(timestamp) {
   if (keys['ArrowRight']) player.rotate(1);
   if (keys['ArrowUp']) player.speed = Math.min(player.speed + 0.1, 5);
   if (keys['ArrowDown']) player.speed = Math.max(player.speed - 0.1, 0);
-  player.update(1); // simplistic update
+  player.update(1, tiles, gridSize); // simplistic update with collision
   player.draw(ctx);
   updateHUD(player);
   drawMinimap(minimapCtx, tiles, player, worldWidth, worldHeight);


### PR DESCRIPTION
## Summary
- Check terrain before moving a ship and block LAND or COAST tiles, allowing sliding along edges
- Pass world tiles and grid size to `Ship.update` for collision handling

## Testing
- `npm test`
- `node - <<'NODE'
import { Ship } from './pirates/entities/ship.js';

const gridSize = 100;
const tiles = [
  [0, 1],
  [0, 1]
];
const ship = new Ship(50, 50);
ship.speed = 100;
ship.angle = 0;
ship.update(1, tiles, gridSize);
console.log('After moving east:', ship.x, ship.y);
ship.angle = Math.PI/4;
ship.update(1, tiles, gridSize);
console.log('After moving northeast along boundary:', ship.x.toFixed(2), ship.y.toFixed(2));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b425a560ec832fade933e989b583c5