### PR TITLE
fix: hook up start button to seed game

### DIFF
--- a/pirates/index.html
+++ b/pirates/index.html
@@ -147,7 +147,7 @@
   <!-- Seed controls to allow starting world with a specific seed -->
   <div id="seedControls" style="position:absolute; top:590px; right:10px; background:rgba(0,0,0,0.7); color:#fff; padding:5px;">
     Seed: <input id="seedInput" type="number" style="width:80px;">
-    <button onclick="startGame(parseFloat(document.getElementById('seedInput').value))">Start</button>
+    <button id="startButton">Start</button>
   </div>
   <!-- Log console -->
   <div id="log"></div>

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -68,6 +68,16 @@ function loop(timestamp) {
 
 start();
 
-window.startGame = seed => {
+function startGame(seed) {
   setup(seed);
-};
+}
+
+window.startGame = startGame;
+
+const startBtn = document.getElementById('startButton');
+if (startBtn) {
+  startBtn.addEventListener('click', () => {
+    const seed = parseFloat(document.getElementById('seedInput').value);
+    startGame(seed);
+  });
+}


### PR DESCRIPTION
## Summary
- replace inline `onclick` call with start button id
- expose `startGame` function and attach start button click handler in `main.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42758c90c832fb287f7653d563b68