### PR TITLE
Center ship by scrolling world and entities

### DIFF
--- a/pirates/entities/city.js
+++ b/pirates/entities/city.js
@@ -7,13 +7,13 @@ export class City {
     this.name = name;
   }
 
-  draw(ctx) {
+  draw(ctx, offsetX = 0, offsetY = 0) {
     const img = assets.city;
     if (img) {
-      ctx.drawImage(img, this.x - img.width / 2, this.y - img.height / 2);
+      ctx.drawImage(img, this.x - img.width / 2 - offsetX, this.y - img.height / 2 - offsetY);
     } else {
       ctx.fillStyle = 'gray';
-      ctx.fillRect(this.x - 8, this.y - 8, 16, 16);
+      ctx.fillRect(this.x - 8 - offsetX, this.y - 8 - offsetY, 16, 16);
     }
   }
 }

--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -45,17 +45,17 @@ export class Ship {
     this.y = newY;
   }
 
-  draw(ctx) {
+  draw(ctx, offsetX = 0, offsetY = 0) {
     const img = assets.ship?.Sloop?.[this.nation] || assets.ship?.Sloop?.England;
     if (img) {
       ctx.save();
-      ctx.translate(this.x, this.y);
+      ctx.translate(this.x - offsetX, this.y - offsetY);
       ctx.rotate(this.angle);
       ctx.drawImage(img, -img.width / 2, -img.height / 2);
       ctx.restore();
     } else {
       ctx.fillStyle = 'brown';
-      ctx.fillRect(this.x - 5, this.y - 5, 10, 10);
+      ctx.fillRect(this.x - 5 - offsetX, this.y - 5 - offsetY, 10, 10);
     }
   }
 }

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -53,14 +53,18 @@ async function start() {
 
 function loop(timestamp) {
   ctx.clearRect(0, 0, CSS_WIDTH, CSS_HEIGHT);
-  drawWorld(ctx, tiles, gridSize, assets);
-  cities.forEach(c => c.draw(ctx));
   if (keys['ArrowLeft']) player.rotate(-1);
   if (keys['ArrowRight']) player.rotate(1);
   if (keys['ArrowUp']) player.speed = Math.min(player.speed + 0.1, 5);
   if (keys['ArrowDown']) player.speed = Math.max(player.speed - 0.1, 0);
   player.update(1, tiles, gridSize); // simplistic update with collision
-  player.draw(ctx);
+
+  const offsetX = player.x - CSS_WIDTH / 2;
+  const offsetY = player.y - CSS_HEIGHT / 2;
+
+  drawWorld(ctx, tiles, gridSize, assets, offsetX, offsetY);
+  cities.forEach(c => c.draw(ctx, offsetX, offsetY));
+  player.draw(ctx, offsetX, offsetY);
   updateHUD(player);
   drawMinimap(minimapCtx, tiles, player, worldWidth, worldHeight);
   requestAnimationFrame(loop);


### PR DESCRIPTION
## Summary
- Center the player ship by computing camera offsets and passing them to world and entity draw routines
- Update Ship and City draw methods to accept offsets and render relative to camera

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4292cb4bc832f832b18e213f26d48