### PR TITLE
Refine pirates asset manifest and city rendering

### DIFF
--- a/pirates/assets.json
+++ b/pirates/assets.json
@@ -1,11 +1,8 @@
 {
-  "city": "assets/villageTB128.png",
-  "island": "assets/grassTB128.png",
   "tiles": {
     "water": "assets/seaTB128.png",
     "land": "assets/grassTB128.png",
     "village": "assets/villageTB128.png",
-    "coast": "assets/grassTB128.png",
     "hill": "assets/hillTB128.png"
   },
   "ship": {

--- a/pirates/entities/city.js
+++ b/pirates/entities/city.js
@@ -8,7 +8,7 @@ export class City {
   }
 
   draw(ctx, offsetX = 0, offsetY = 0) {
-    const img = assets.city;
+    const img = assets.tiles.village;
     if (img) {
       ctx.drawImage(img, this.x - img.width / 2 - offsetX, this.y - img.height / 2 - offsetY);
     } else {


### PR DESCRIPTION
## Summary
- Drop obsolete `city`, `island`, and `tiles.coast` entries from pirate asset manifest
- Render cities using the `village` tile asset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b42bc867cc832f893db4073c7c5152