### PR TITLE
Use CDN for simplex-noise

### DIFF
--- a/pirates/world.js
+++ b/pirates/world.js
@@ -1,4 +1,4 @@
-import { createNoise2D } from 'simplex-noise';
+import { createNoise2D } from 'https://cdn.skypack.dev/simplex-noise';
 
 export const Terrain = {
   WATER: 0,


### PR DESCRIPTION
## Summary
- use Skypack CDN for simplex-noise import in world generator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42c531a30832f8cac5d4d03971810