### PR TITLE
Add basic trading system

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -9,6 +9,9 @@ export class Ship {
     this.speed = 0;
     this.angle = 0;
     this.turnSpeed = 0.05;
+    this.cargo = {};
+    this.cargoCapacity = 20;
+    this.gold = 100;
   }
 
   rotate(direction) {

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -6,6 +6,7 @@ import { initHUD, updateHUD } from './ui/hud.js';
 import { initMinimap, drawMinimap } from './ui/minimap.js';
 import { initLog } from './ui/log.js';
 import { bus } from './bus.js';
+import { openTradeMenu, closeTradeMenu } from './ui/trade.js';
 
 const worldWidth = 4800, worldHeight = 3200, gridSize = 128;
 const CSS_WIDTH = 800, CSS_HEIGHT = 600;
@@ -102,6 +103,13 @@ function loop(timestamp) {
   player.draw(ctx, offsetX, offsetY);
   updateHUD(player);
   drawMinimap(minimapCtx, tiles, player, worldWidth, worldHeight);
+
+  const nearbyCity = cities.find(c => Math.hypot(player.x - c.x, player.y - c.y) < 32);
+  if (nearbyCity) {
+    openTradeMenu(player);
+  } else {
+    closeTradeMenu();
+  }
   requestAnimationFrame(loop);
 }
 

--- a/pirates/ui/trade.js
+++ b/pirates/ui/trade.js
@@ -1,0 +1,75 @@
+const GOODS = ['Sugar', 'Rum', 'Tobacco', 'Cotton'];
+const PRICES = { Sugar: 10, Rum: 12, Tobacco: 15, Cotton: 8 };
+
+function cargoUsed(player) {
+  return Object.values(player.cargo).reduce((a, b) => a + b, 0);
+}
+
+export function openTradeMenu(player) {
+  const menu = document.getElementById('tradeMenu');
+  if (!menu || !player) return;
+  menu.innerHTML = '';
+
+  const goldDiv = document.createElement('div');
+  goldDiv.textContent = `Gold: ${player.gold}`;
+  menu.appendChild(goldDiv);
+
+  const capacityDiv = document.createElement('div');
+  capacityDiv.textContent = `Cargo: ${cargoUsed(player)}/${player.cargoCapacity}`;
+  menu.appendChild(capacityDiv);
+
+  const table = document.createElement('table');
+  const header = document.createElement('tr');
+  header.innerHTML = '<th>Good</th><th>Qty</th><th>Price</th><th></th><th></th>';
+  table.appendChild(header);
+
+  GOODS.forEach(good => {
+    const row = document.createElement('tr');
+    const qty = player.cargo[good] || 0;
+    row.innerHTML = `<td>${good}</td><td>${qty}</td><td>${PRICES[good]}g</td>`;
+
+    const buyCell = document.createElement('td');
+    const buyBtn = document.createElement('button');
+    buyBtn.textContent = 'Buy';
+    buyBtn.onclick = () => {
+      if (player.gold >= PRICES[good] && cargoUsed(player) < player.cargoCapacity) {
+        player.gold -= PRICES[good];
+        player.cargo[good] = (player.cargo[good] || 0) + 1;
+        openTradeMenu(player);
+      }
+    };
+    buyCell.appendChild(buyBtn);
+    row.appendChild(buyCell);
+
+    const sellCell = document.createElement('td');
+    const sellBtn = document.createElement('button');
+    sellBtn.textContent = 'Sell';
+    sellBtn.onclick = () => {
+      if ((player.cargo[good] || 0) > 0) {
+        player.cargo[good] -= 1;
+        player.gold += PRICES[good];
+        openTradeMenu(player);
+      }
+    };
+    sellCell.appendChild(sellBtn);
+    row.appendChild(sellCell);
+
+    table.appendChild(row);
+  });
+
+  menu.appendChild(table);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', () => {
+    menu.style.display = 'none';
+  });
+  menu.appendChild(closeBtn);
+
+  menu.style.display = 'block';
+}
+
+export function closeTradeMenu() {
+  const menu = document.getElementById('tradeMenu');
+  if (menu) menu.style.display = 'none';
+}


### PR DESCRIPTION
## Summary
- Detect when the player ship is near a city and show a trade menu
- Add trade UI listing goods, cargo capacity, and buy/sell prices
- Extend Ship with cargo, capacity, and gold for trading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b43417b208832fbd6334f7f421a76b