### PR TITLE
Fix path handling for nested assets

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ import path from 'path';
 const port = process.env.PORT || 8000;
 
 const server = http.createServer((req, res) => {
-  const requestedPath = req.url === '/' ? '/index.html' : req.url;
+  const requestedPath = req.url === '/' ? 'pirates/index.html' : req.url.replace(/^\/+/, '');
   const filePath = path.join(process.cwd(), requestedPath);
 
   fs.readFile(filePath, (err, data) => {


### PR DESCRIPTION
## Summary
- Strip leading slashes and default to pirates/index.html when resolving requests
- Ensure nested asset URLs resolve relative to repository root

## Testing
- `npm test`
- `curl -s localhost:8000/pirates/assets.json | head`


------
https://chatgpt.com/codex/tasks/task_e_68b4393c9dd4832fba717eabecde8c66