### PR TITLE
feat: add isometric world rendering

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -15,6 +15,7 @@ import { startBoarding } from './boarding.js';
 import { initCommandKeys, updateCommandKeys } from './ui/commandKeys.js';
 
 const worldWidth = 4800, worldHeight = 3200, gridSize = 128;
+let tileWidth = gridSize, tileHeight = gridSize / 2;
 const CSS_WIDTH = 800, CSS_HEIGHT = 600;
 
 const canvas = document.getElementById('gameCanvas');
@@ -117,6 +118,11 @@ function setup(seed=Math.random()) {
 
 async function start() {
   await loadAssets(gridSize);
+  const sampleTile = assets.tiles?.land || assets.tiles?.water;
+  if (sampleTile) {
+    tileWidth = sampleTile.width;
+    tileHeight = sampleTile.height;
+  }
   setup();
   requestAnimationFrame(loop);
 }
@@ -133,7 +139,7 @@ function loop(timestamp) {
   const offsetX = player.x - CSS_WIDTH / 2;
   const offsetY = player.y - CSS_HEIGHT / 2;
 
-  drawWorld(ctx, tiles, gridSize, assets, offsetX, offsetY);
+  drawWorld(ctx, tiles, tileWidth, tileHeight, assets, offsetX, offsetY);
   cities.forEach(c => c.draw(ctx, offsetX, offsetY));
   npcShips.forEach(n => {
     n.update(1, tiles, gridSize, player);

--- a/pirates/world.js
+++ b/pirates/world.js
@@ -60,7 +60,18 @@ function seededRandom(seed) {
   return x - Math.floor(x);
 }
 
-export function drawWorld(ctx, tiles, gridSize, assets, offsetX=0, offsetY=0) {
+export function worldToIso(r, c, tileWidth, tileHeight, offsetX = 0, offsetY = 0) {
+  return {
+    x: (c - r) * tileWidth / 2 - offsetX,
+    y: (c + r) * tileHeight / 2 - offsetY
+  };
+}
+
+export function drawWorld(ctx, tiles, tileWidth, tileHeight, assets, offsetX=0, offsetY=0) {
+  tileWidth = tileWidth ?? assets.tiles?.land?.width ?? assets.tiles?.water?.width;
+  tileHeight = tileHeight ?? assets.tiles?.land?.height ?? assets.tiles?.water?.height ?? (tileWidth ? tileWidth / 2 : undefined);
+  if (!tileWidth || !tileHeight) return;
+
   for (let r = 0; r < tiles.length; r++) {
     for (let c = 0; c < tiles[0].length; c++) {
       const t = tiles[r][c];
@@ -71,9 +82,8 @@ export function drawWorld(ctx, tiles, gridSize, assets, offsetX=0, offsetY=0) {
       else if (t === Terrain.COAST) img = assets.tiles?.coast || assets.tiles?.land;
       else img = assets.tiles?.land;
       if (!img) continue;
-      const x = c * gridSize - offsetX;
-      const y = r * gridSize - offsetY;
-      ctx.drawImage(img, x, y, gridSize, gridSize);
+      const { x, y } = worldToIso(r, c, tileWidth, tileHeight, offsetX, offsetY);
+      ctx.drawImage(img, x, y, tileWidth, tileHeight);
     }
   }
 }


### PR DESCRIPTION
## Summary
- switch world tile rendering to isometric projection
- expose tile dimensions and add worldToIso utility
- derive tile dimensions from asset sizes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b43e5244e4832f8d952f4aeb2c2a4e