### PR TITLE
feat: add cartesian to isometric helper

### DIFF
--- a/pirates/entities/city.js
+++ b/pirates/entities/city.js
@@ -1,4 +1,5 @@
 import { assets } from '../assets.js';
+import { cartToIso } from '../world.js';
 
 export class City {
   constructor(x, y, name) {
@@ -8,12 +9,16 @@ export class City {
   }
 
   draw(ctx, offsetX = 0, offsetY = 0) {
+    const { isoX, isoY } = cartToIso(this.x, this.y);
     const img = assets.tiles.village;
     if (img) {
-      ctx.drawImage(img, this.x - img.width / 2 - offsetX, this.y - img.height / 2 - offsetY);
+      ctx.save();
+      ctx.translate(isoX - offsetX, isoY - offsetY);
+      ctx.drawImage(img, -img.width / 2, -img.height / 2);
+      ctx.restore();
     } else {
       ctx.fillStyle = 'gray';
-      ctx.fillRect(this.x - 8 - offsetX, this.y - 8 - offsetY, 16, 16);
+      ctx.fillRect(isoX - 8 - offsetX, isoY - 8 - offsetY, 16, 16);
     }
   }
 }

--- a/pirates/entities/projectile.js
+++ b/pirates/entities/projectile.js
@@ -1,3 +1,5 @@
+import { cartToIso } from '../world.js';
+
 export class Projectile {
   constructor(x, y, angle) {
     this.x = x;
@@ -15,8 +17,9 @@ export class Projectile {
   }
 
   draw(ctx, offsetX = 0, offsetY = 0) {
+    const { isoX, isoY } = cartToIso(this.x, this.y);
     ctx.save();
-    ctx.translate(this.x - offsetX, this.y - offsetY);
+    ctx.translate(isoX - offsetX, isoY - offsetY);
     ctx.fillStyle = 'black';
     ctx.beginPath();
     ctx.arc(0, 0, 2, 0, Math.PI * 2);

--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -1,5 +1,5 @@
 import { assets } from '../assets.js';
-import { Terrain } from '../world.js';
+import { Terrain, cartToIso } from '../world.js';
 import { Projectile } from './projectile.js';
 
 export class Ship {
@@ -75,14 +75,16 @@ export class Ship {
     if (!this.sunk) {
       const img = assets.ship?.Sloop?.[this.nation] || assets.ship?.Sloop?.England;
       if (img) {
+        const { isoX, isoY } = cartToIso(this.x, this.y);
         ctx.save();
-        ctx.translate(this.x - offsetX, this.y - offsetY);
+        ctx.translate(isoX - offsetX, isoY - offsetY);
         ctx.rotate(this.angle);
         ctx.drawImage(img, -img.width / 2, -img.height / 2);
         ctx.restore();
       } else {
+        const { isoX, isoY } = cartToIso(this.x, this.y);
         ctx.fillStyle = 'brown';
-        ctx.fillRect(this.x - 5 - offsetX, this.y - 5 - offsetY, 10, 10);
+        ctx.fillRect(isoX - 5 - offsetX, isoY - 5 - offsetY, 10, 10);
       }
     }
 

--- a/pirates/world.js
+++ b/pirates/world.js
@@ -1,4 +1,5 @@
 import { createNoise2D } from 'https://cdn.skypack.dev/simplex-noise';
+import { assets } from './assets.js';
 
 export const Terrain = {
   WATER: 0,
@@ -64,6 +65,16 @@ export function worldToIso(r, c, tileWidth, tileHeight, offsetX = 0, offsetY = 0
   return {
     x: (c - r) * tileWidth / 2 - offsetX,
     y: (c + r) * tileHeight / 2 - offsetY
+  };
+}
+
+export function cartToIso(x, y, tileWidth, tileHeight) {
+  tileWidth = tileWidth ?? assets.tiles?.land?.width ?? assets.tiles?.water?.width;
+  tileHeight = tileHeight ?? assets.tiles?.land?.height ?? assets.tiles?.water?.height ?? (tileWidth ? tileWidth / 2 : undefined);
+  if (!tileWidth || !tileHeight) return { isoX: x, isoY: y };
+  return {
+    isoX: (x - y) / 2,
+    isoY: (x + y) * (tileHeight / (2 * tileWidth))
   };
 }
 


### PR DESCRIPTION
## Summary
- add `cartToIso` helper using world tile dimensions
- render ships, cities, and projectiles using isometric coordinates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b43f1266e8832fa158515148ca385f