### PR TITLE
Offset world tiles by half step rows

### DIFF
--- a/pirates/world.js
+++ b/pirates/world.js
@@ -62,8 +62,9 @@ function seededRandom(seed) {
 }
 
 export function worldToHalfStep(r, c, tileWidth, tileHeight, offsetX = 0, offsetY = 0) {
+  const rowShift = (r % 2 === 0) ? -tileWidth / 2 : tileWidth / 2;
   return {
-    x: c * tileWidth / 2 - offsetX,
+    x: c * tileWidth / 2 + rowShift - offsetX,
     y: r * tileHeight / 2 - offsetY
   };
 }


### PR DESCRIPTION
## Summary
- offset every other row by half a tile width to create staggered layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b442ec3d34832f89afba22b6caf523