### PR TITLE
Refine isometric projection

### DIFF
--- a/pirates/entities/city.js
+++ b/pirates/entities/city.js
@@ -8,8 +8,8 @@ export class City {
     this.name = name;
   }
 
-  draw(ctx, offsetX = 0, offsetY = 0) {
-    const { isoX, isoY } = cartToIso(this.x, this.y);
+  draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {
+    const { isoX, isoY } = cartToIso(this.x, this.y, tileWidth, tileIsoHeight, tileImageHeight);
     const img = assets.tiles.village;
     if (img) {
       ctx.save();

--- a/pirates/entities/projectile.js
+++ b/pirates/entities/projectile.js
@@ -16,8 +16,8 @@ export class Projectile {
     return this.life > 0;
   }
 
-  draw(ctx, offsetX = 0, offsetY = 0) {
-    const { isoX, isoY } = cartToIso(this.x, this.y);
+  draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {
+    const { isoX, isoY } = cartToIso(this.x, this.y, tileWidth, tileIsoHeight, tileImageHeight);
     ctx.save();
     ctx.translate(isoX - offsetX, isoY - offsetY);
     ctx.fillStyle = 'black';

--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -71,24 +71,24 @@ export class Ship {
     this.projectiles = this.projectiles.filter(p => p.update());
   }
 
-  draw(ctx, offsetX = 0, offsetY = 0) {
+  draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {
     if (!this.sunk) {
       const img = assets.ship?.Sloop?.[this.nation] || assets.ship?.Sloop?.England;
       if (img) {
-        const { isoX, isoY } = cartToIso(this.x, this.y);
+        const { isoX, isoY } = cartToIso(this.x, this.y, tileWidth, tileIsoHeight, tileImageHeight);
         ctx.save();
         ctx.translate(isoX - offsetX, isoY - offsetY);
         ctx.rotate(this.angle);
         ctx.drawImage(img, -img.width / 2, -img.height / 2);
         ctx.restore();
       } else {
-        const { isoX, isoY } = cartToIso(this.x, this.y);
+        const { isoX, isoY } = cartToIso(this.x, this.y, tileWidth, tileIsoHeight, tileImageHeight);
         ctx.fillStyle = 'brown';
         ctx.fillRect(isoX - 5 - offsetX, isoY - 5 - offsetY, 10, 10);
       }
     }
 
-    this.projectiles.forEach(p => p.draw(ctx, offsetX, offsetY));
+    this.projectiles.forEach(p => p.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight));
   }
 
   fireCannons() {

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -15,7 +15,9 @@ import { startBoarding } from './boarding.js';
 import { initCommandKeys, updateCommandKeys } from './ui/commandKeys.js';
 
 const worldWidth = 4800, worldHeight = 3200, gridSize = 128;
-let tileWidth = gridSize, tileHeight = gridSize / 2;
+let tileWidth = gridSize,
+    tileIsoHeight = gridSize / 2,
+    tileImageHeight = gridSize;
 const CSS_WIDTH = 800, CSS_HEIGHT = 600;
 
 const canvas = document.getElementById('gameCanvas');
@@ -121,7 +123,8 @@ async function start() {
   const sampleTile = assets.tiles?.land || assets.tiles?.water;
   if (sampleTile) {
     tileWidth = sampleTile.width;
-    tileHeight = sampleTile.height;
+    tileImageHeight = sampleTile.height;
+    tileIsoHeight = sampleTile.height / 2;
   }
   setup();
   requestAnimationFrame(loop);
@@ -139,15 +142,15 @@ function loop(timestamp) {
   const offsetX = player.x - CSS_WIDTH / 2;
   const offsetY = player.y - CSS_HEIGHT / 2;
 
-  drawWorld(ctx, tiles, tileWidth, tileHeight, assets, offsetX, offsetY);
-  cities.forEach(c => c.draw(ctx, offsetX, offsetY));
+  drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight, assets, offsetX, offsetY);
+  cities.forEach(c => c.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight));
   npcShips.forEach(n => {
     n.update(1, tiles, gridSize, player);
     const dist = Math.hypot(player.x - n.x, player.y - n.y);
     if (dist < 200) n.fireCannons();
-    n.draw(ctx, offsetX, offsetY);
+    n.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight);
   });
-  player.draw(ctx, offsetX, offsetY);
+  player.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight);
 
   // projectile collisions
   npcShips.forEach(n => {

--- a/pirates/world.js
+++ b/pirates/world.js
@@ -61,28 +61,29 @@ function seededRandom(seed) {
   return x - Math.floor(x);
 }
 
-export function worldToHalfStep(r, c, tileWidth, tileHeight, offsetX = 0, offsetY = 0) {
-  const rowShift = (r % 2 === 0) ? -tileWidth / 2 : tileWidth / 2;
+export function worldToIso(r, c, tileWidth, tileIsoHeight, tileImageHeight, offsetX = 0, offsetY = 0) {
   return {
-    x: c * tileWidth / 2 + rowShift - offsetX,
-    y: r * tileHeight / 2 - offsetY
+    x: (c - r) * tileWidth / 2 - offsetX,
+    y: (c + r) * tileIsoHeight / 2 - (tileImageHeight - tileIsoHeight) - offsetY
   };
 }
 
-export function cartToIso(x, y, tileWidth, tileHeight) {
+export function cartToIso(x, y, tileWidth, tileIsoHeight, tileImageHeight) {
   tileWidth = tileWidth ?? assets.tiles?.land?.width ?? assets.tiles?.water?.width;
-  tileHeight = tileHeight ?? assets.tiles?.land?.height ?? assets.tiles?.water?.height ?? (tileWidth ? tileWidth / 2 : undefined);
-  if (!tileWidth || !tileHeight) return { isoX: x, isoY: y };
+  tileImageHeight = tileImageHeight ?? assets.tiles?.land?.height ?? assets.tiles?.water?.height ?? tileWidth;
+  tileIsoHeight = tileIsoHeight ?? tileImageHeight / 2;
+  if (!tileWidth || !tileIsoHeight) return { isoX: x, isoY: y };
   return {
     isoX: (x - y) / 2,
-    isoY: (x + y) * (tileHeight / (2 * tileWidth))
+    isoY: (x + y) * (tileIsoHeight / (2 * tileWidth)) - tileIsoHeight / 2
   };
 }
 
-export function drawWorld(ctx, tiles, tileWidth, tileHeight, assets, offsetX=0, offsetY=0) {
+export function drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight, assets, offsetX=0, offsetY=0) {
   tileWidth = tileWidth ?? assets.tiles?.land?.width ?? assets.tiles?.water?.width;
-  tileHeight = tileHeight ?? assets.tiles?.land?.height ?? assets.tiles?.water?.height ?? (tileWidth ? tileWidth / 2 : undefined);
-  if (!tileWidth || !tileHeight) return;
+  tileImageHeight = tileImageHeight ?? assets.tiles?.land?.height ?? assets.tiles?.water?.height ?? tileWidth;
+  tileIsoHeight = tileIsoHeight ?? tileImageHeight / 2;
+  if (!tileWidth || !tileIsoHeight || !tileImageHeight) return;
 
   for (let r = 0; r < tiles.length; r++) {
     for (let c = 0; c < tiles[0].length; c++) {
@@ -94,8 +95,8 @@ export function drawWorld(ctx, tiles, tileWidth, tileHeight, assets, offsetX=0, 
       else if (t === Terrain.COAST) img = assets.tiles?.coast || assets.tiles?.land;
       else img = assets.tiles?.land;
       if (!img) continue;
-      const { x, y } = worldToHalfStep(r, c, tileWidth, tileHeight, offsetX, offsetY);
-      ctx.drawImage(img, x, y, tileWidth, tileHeight);
+      const { x, y } = worldToIso(r, c, tileWidth, tileIsoHeight, tileImageHeight, offsetX, offsetY);
+      ctx.drawImage(img, x, y, img.width, tileImageHeight);
     }
   }
 }


### PR DESCRIPTION
## Summary
- separate logical and image tile heights for isometric math
- correct world-to-screen conversion with `worldToIso`
- update entities to project using new tile dimensions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b72f5c9b04832fbf3b01c1e4d9157e