### PR TITLE
Use 128px tiles and scale world dimensions

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -14,7 +14,10 @@ import { openTradeMenu, closeTradeMenu } from './ui/trade.js';
 import { startBoarding } from './boarding.js';
 import { initCommandKeys, updateCommandKeys } from './ui/commandKeys.js';
 
-const worldWidth = 4800, worldHeight = 3200, gridSize = 128;
+const TILE_SIZE = 128;
+const worldWidth = 75 * TILE_SIZE;
+const worldHeight = 50 * TILE_SIZE;
+const gridSize = TILE_SIZE;
 let tileWidth = gridSize,
     tileIsoHeight = gridSize / 2,
     tileImageHeight = gridSize;


### PR DESCRIPTION
## Summary
- Centralize tile sizing with a `TILE_SIZE` constant set to 128px
- Derive world width/height and tile rendering metrics from this base size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b731c10bdc832fa30d6afef278b648