### PR TITLE
Scale tile assets uniformly and align grid metrics

### DIFF
--- a/pirates/assets.js
+++ b/pirates/assets.js
@@ -35,7 +35,17 @@ async function loadNested(src, target, path = []){
 function loadImage(url, isTile = false){
   return new Promise(resolve => {
     const img = new Image();
-    img.onload = () => resolve(img);
+    img.onload = () => {
+      if (isTile){
+        const canvas = document.createElement('canvas');
+        canvas.width = canvas.height = gridSize;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, gridSize, gridSize);
+        resolve(canvas);
+      } else {
+        resolve(img);
+      }
+    };
     img.onerror = () => {
       console.warn('Failed to load image:', url);
       if (isTile){

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -123,12 +123,8 @@ function setup(seed=Math.random()) {
 
 async function start() {
   await loadAssets(gridSize);
-  const sampleTile = assets.tiles?.land || assets.tiles?.water;
-  if (sampleTile) {
-    tileWidth = sampleTile.width;
-    tileImageHeight = sampleTile.height;
-    tileIsoHeight = sampleTile.height / 2;
-  }
+  tileWidth = tileImageHeight = gridSize;
+  tileIsoHeight = gridSize / 2;
   setup();
   requestAnimationFrame(loop);
 }


### PR DESCRIPTION
## Summary
- Render tile images onto a standardized gridSize canvas for consistent scaling.
- Simplify tile sizing by setting all tile metrics to gridSize during startup.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7339c5d4c832f9795722d37331685