### PR TITLE
Convert world draw offsets to isometric

### DIFF
--- a/pirates/world.js
+++ b/pirates/world.js
@@ -114,6 +114,8 @@ export function drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight,
   let firstCol = Math.max(0, Math.floor(Math.min(...cVals)));
   let lastCol = Math.min(tiles[0].length - 1, Math.ceil(Math.max(...cVals)));
 
+  const { isoX, isoY } = cartToIso(offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight);
+
   for (let r = firstRow; r <= lastRow; r++) {
     for (let c = firstCol; c <= lastCol; c++) {
       const t = tiles[r][c];
@@ -124,7 +126,7 @@ export function drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight,
       else if (t === Terrain.COAST) img = assets.tiles?.coast || assets.tiles?.land;
       else img = assets.tiles?.land;
       if (!img) continue;
-      const { x, y } = worldToIso(r, c, tileWidth, tileIsoHeight, tileImageHeight, offsetX, offsetY);
+      const { x, y } = worldToIso(r, c, tileWidth, tileIsoHeight, tileImageHeight, isoX, isoY);
       ctx.drawImage(img, x, y, img.width, tileImageHeight);
     }
   }


### PR DESCRIPTION
## Summary
- Convert draw offsets from Cartesian to isometric space before rendering tiles.
- Use converted offsets when computing tile positions to keep world aligned with movement.

## Testing
- `node - <<'NODE'
function worldToIso(r, c, tileWidth, tileIsoHeight, tileImageHeight, offsetX = 0, offsetY = 0) {
  return {
    x: (c - r) * tileWidth / 2 - offsetX,
    y: (c + r) * tileIsoHeight / 2 - (tileImageHeight - tileIsoHeight) - offsetY
  };
}

function cartToIso(x, y, tileWidth, tileIsoHeight, tileImageHeight) {
  if (!tileWidth || !tileIsoHeight) return { isoX: x, isoY: y };
  return {
    isoX: (x - y) / 2,
    isoY: (x + y) * (tileIsoHeight / (2 * tileWidth)) - tileIsoHeight / 2
  };
}

const tileW=64, tileIH=32, tileImgH=64, offsetX=100, offsetY=50;
const { isoX, isoY } = cartToIso(offsetX, offsetY, tileW, tileIH, tileImgH);
const t1 = worldToIso(5, 5, tileW, tileIH, tileImgH, 0, 0);
const t2 = worldToIso(5, 5, tileW, tileIH, tileImgH, isoX, isoY);
console.log('matchX', t2.x === t1.x - isoX, 'matchY', t2.y === t1.y - isoY);
NODE`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b73888d6a4832f8daabd146c012741