### PR TITLE
Fix world render area for high DPI displays

### DIFF
--- a/pirates/world.js
+++ b/pirates/world.js
@@ -87,12 +87,12 @@ export function drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight,
   tileIsoHeight = tileIsoHeight ?? tileImageHeight / 2;
   if (!tileWidth || !tileIsoHeight || !tileImageHeight) return;
 
-  const canvasWidth = ctx.canvas?.width ?? 0;
-  const canvasHeight = ctx.canvas?.height ?? 0;
+  const canvasWidth = ctx.canvas?.clientWidth ?? ctx.canvas?.width ?? 0;
+  const canvasHeight = ctx.canvas?.clientHeight ?? ctx.canvas?.height ?? 0;
 
-  function screenToTile(x, y) {
-    const sy = y + offsetY + (tileImageHeight - tileIsoHeight);
-    const sx = x + offsetX;
+  function screenToTile(cssX, cssY) {
+    const sy = cssY + offsetY + (tileImageHeight - tileIsoHeight);
+    const sx = cssX + offsetX;
     return {
       r: sy / tileIsoHeight - sx / tileWidth,
       c: sy / tileIsoHeight + sx / tileWidth


### PR DESCRIPTION
## Summary
- compute canvas size from CSS dimensions so visible tile calculations ignore devicePixelRatio
- use CSS-based coordinates in `screenToTile`

## Testing
- `node - <<'NODE' ...` (drawWorld) - identical tile counts at dpr 1, 1.5, 2
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b73ac58a74832fb9c27a0ab39e3d55