### PR TITLE
Ensure ship projectiles update despite collisions

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -32,6 +32,8 @@ export class Ship {
   }
 
   update(dt, tiles, gridSize) {
+    this.projectiles = this.projectiles.filter(p => p.update());
+
     const { x: dx, y: dy } = this.forward(dt);
     let newX = this.x + dx;
     let newY = this.y + dy;
@@ -67,8 +69,6 @@ export class Ship {
 
     this.x = newX;
     this.y = newY;
-
-    this.projectiles = this.projectiles.filter(p => p.update());
   }
 
   draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {


### PR DESCRIPTION
## Summary
- Move projectile updates to the start of `Ship.update` so cannonballs keep moving even if the ship hits terrain

## Testing
- `npm test`
- `node /tmp/projectile_test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68b7402800c8832fbbd227e4781bbebc