### PR TITLE
Add ship movement friction and speed clamping

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -69,6 +69,12 @@ export class Ship {
 
     this.x = newX;
     this.y = newY;
+
+    // Apply friction so ships gradually slow down
+    this.speed *= 0.98;
+    if (Math.abs(this.speed) < 0.01) {
+      this.speed = 0;
+    }
   }
 
   draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {


### PR DESCRIPTION
## Summary
- Apply per-frame friction and zero out near-stationary speeds in pirate ships

## Testing
- `npm test`
- `node -e "let speed=1; for(let i=0;i<500 && speed>0;i++){speed*=0.98;if(Math.abs(speed)<0.01)speed=0;} console.log('final',speed);"`


------
https://chatgpt.com/codex/tasks/task_e_68b74102363c832fb8c2d05ca3881b58