### PR TITLE
feat: add dynamic trade pricing

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -204,7 +204,8 @@ function loop(timestamp) {
   const nearbyCity = cities.find(c => Math.hypot(player.x - c.x, player.y - c.y) < 32);
   updateCommandKeys({ nearCity: !!nearbyCity, nearEnemy });
   if (nearbyCity) {
-    openTradeMenu(player);
+    const metadata = cityMetadata.get(nearbyCity);
+    openTradeMenu(player, nearbyCity, metadata);
   } else {
     closeTradeMenu();
   }

--- a/pirates/ui/trade.js
+++ b/pirates/ui/trade.js
@@ -1,16 +1,34 @@
 import { bus } from '../bus.js';
+import { updateHUD } from './hud.js';
 
-const GOODS = ['Sugar', 'Rum', 'Tobacco', 'Cotton'];
 const PRICES = { Sugar: 10, Rum: 12, Tobacco: 15, Cotton: 8 };
+
+function listGoods(metadata) {
+  const goods = new Set();
+  if (metadata?.supplies) metadata.supplies.forEach(g => goods.add(g));
+  if (metadata?.demands) metadata.demands.forEach(g => goods.add(g));
+  return Array.from(goods);
+}
+
+function priceFor(good, metadata) {
+  let price = PRICES[good];
+  if (metadata?.supplies?.includes(good)) price = Math.round(price * 0.8);
+  if (metadata?.demands?.includes(good)) price = Math.round(price * 1.2);
+  return price;
+}
 
 function cargoUsed(player) {
   return Object.values(player.cargo).reduce((a, b) => a + b, 0);
 }
 
-export function openTradeMenu(player) {
+export function openTradeMenu(player, city, metadata) {
   const menu = document.getElementById('tradeMenu');
   if (!menu || !player) return;
   menu.innerHTML = '';
+
+  const title = document.createElement('div');
+  if (city?.name) title.textContent = `Trading in ${city.name}`;
+  menu.appendChild(title);
 
   const goldDiv = document.createElement('div');
   goldDiv.textContent = `Gold: ${player.gold}`;
@@ -25,20 +43,22 @@ export function openTradeMenu(player) {
   header.innerHTML = '<th>Good</th><th>Qty</th><th>Price</th><th></th><th></th>';
   table.appendChild(header);
 
-  GOODS.forEach(good => {
+  listGoods(metadata).forEach(good => {
     const row = document.createElement('tr');
     const qty = player.cargo[good] || 0;
-    row.innerHTML = `<td>${good}</td><td>${qty}</td><td>${PRICES[good]}g</td>`;
+    const price = priceFor(good, metadata);
+    row.innerHTML = `<td>${good}</td><td>${qty}</td><td>${price}g</td>`;
 
     const buyCell = document.createElement('td');
     const buyBtn = document.createElement('button');
     buyBtn.textContent = 'Buy';
     buyBtn.onclick = () => {
-      if (player.gold >= PRICES[good] && cargoUsed(player) < player.cargoCapacity) {
-        player.gold -= PRICES[good];
+      if (player.gold >= price && cargoUsed(player) < player.cargoCapacity) {
+        player.gold -= price;
         player.cargo[good] = (player.cargo[good] || 0) + 1;
-        bus.emit('log', `Bought 1 ${good} for ${PRICES[good]}g`);
-        openTradeMenu(player);
+        bus.emit('log', `Bought 1 ${good} for ${price}g`);
+        updateHUD(player);
+        openTradeMenu(player, city, metadata);
       }
     };
     buyCell.appendChild(buyBtn);
@@ -50,9 +70,10 @@ export function openTradeMenu(player) {
     sellBtn.onclick = () => {
       if ((player.cargo[good] || 0) > 0) {
         player.cargo[good] -= 1;
-        player.gold += PRICES[good];
-        bus.emit('log', `Sold 1 ${good} for ${PRICES[good]}g`);
-        openTradeMenu(player);
+        player.gold += price;
+        bus.emit('log', `Sold 1 ${good} for ${price}g`);
+        updateHUD(player);
+        openTradeMenu(player, city, metadata);
       }
     };
     sellCell.appendChild(sellBtn);


### PR DESCRIPTION
## Summary
- pass city metadata into the trade menu
- build trade menu from city supplies and demands with dynamic pricing
- update HUD after buying or selling goods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74306f38c832fbd77c973ac446790