### PR TITLE
Add governor, tavern, and shipwright menus with new city interactions

### DIFF
--- a/pirates/index.html
+++ b/pirates/index.html
@@ -89,9 +89,10 @@
       display: none;
       z-index: 100;
     }
-    /* Governor and upgrade overlays */
+    /* Governor, tavern, and upgrade overlays */
     #governorMenu,
-    #upgradeMenu {
+    #upgradeMenu,
+    #tavernMenu {
       position: absolute;
       top: 50%;
       left: 50%;
@@ -143,8 +144,9 @@
   <div id="tradeMenu"></div>
   <!-- Governor and Upgrade Menus -->
   <div id="governorMenu"></div>
-    <div id="upgradeMenu"></div>
-    <div id="cardContainer" class="isometric-cards"></div>
+  <div id="upgradeMenu"></div>
+  <div id="tavernMenu"></div>
+  <div id="cardContainer" class="isometric-cards"></div>
 
     <script type="module" src="main.js"></script>
 </body>

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -11,6 +11,9 @@ import { Quest } from './quest.js';
 import { questManager } from './questManager.js';
 import { bus } from './bus.js';
 import { openTradeMenu, closeTradeMenu } from './ui/trade.js';
+import { openGovernorMenu, closeGovernorMenu } from './ui/governor.js';
+import { openUpgradeMenu, closeUpgradeMenu } from './ui/upgrade.js';
+import { openTavernMenu, closeTavernMenu } from './ui/tavern.js';
 import { startBoarding } from './boarding.js';
 import { initCommandKeys, updateCommandKeys } from './ui/commandKeys.js';
 
@@ -205,9 +208,39 @@ function loop(timestamp) {
   updateCommandKeys({ nearCity: !!nearbyCity, nearEnemy });
   if (nearbyCity) {
     const metadata = cityMetadata.get(nearbyCity);
-    openTradeMenu(player, nearbyCity, metadata);
+    if (keys['t'] || keys['T']) {
+      closeGovernorMenu();
+      closeTavernMenu();
+      closeUpgradeMenu();
+      openTradeMenu(player, nearbyCity, metadata);
+      keys['t'] = keys['T'] = false;
+    }
+    if (keys['g'] || keys['G']) {
+      closeTradeMenu();
+      closeTavernMenu();
+      closeUpgradeMenu();
+      openGovernorMenu(player, nearbyCity, metadata);
+      keys['g'] = keys['G'] = false;
+    }
+    if (keys['v'] || keys['V']) {
+      closeTradeMenu();
+      closeGovernorMenu();
+      closeUpgradeMenu();
+      openTavernMenu(player, nearbyCity);
+      keys['v'] = keys['V'] = false;
+    }
+    if (keys['u'] || keys['U']) {
+      closeTradeMenu();
+      closeGovernorMenu();
+      closeTavernMenu();
+      openUpgradeMenu(player);
+      keys['u'] = keys['U'] = false;
+    }
   } else {
     closeTradeMenu();
+    closeGovernorMenu();
+    closeTavernMenu();
+    closeUpgradeMenu();
   }
   requestAnimationFrame(loop);
 }

--- a/pirates/ui/commandKeys.js
+++ b/pirates/ui/commandKeys.js
@@ -9,6 +9,9 @@ export function initCommandKeys() {
     <div data-cmd="pause">P: Pause/Unpause</div>
     <div data-cmd="minimap">M: Toggle minimap</div>
     <div data-cmd="trade" style="display:none">T: Trade (if near a city)</div>
+    <div data-cmd="governor" style="display:none">G: Visit governor</div>
+    <div data-cmd="tavern" style="display:none">V: Visit tavern</div>
+    <div data-cmd="upgrade" style="display:none">U: Shipwright</div>
     <div data-cmd="board" style="display:none">B: Board enemy ship</div>
     <div data-cmd="capture" style="display:none">C: Capture enemy ship</div>
     <div data-cmd="save">S: Save game</div>
@@ -20,6 +23,9 @@ export function updateCommandKeys({ nearCity = false, nearEnemy = false }) {
   const div = document.getElementById('commandKeys');
   if (!div) return;
   toggle(div.querySelector('[data-cmd="trade"]'), nearCity);
+   toggle(div.querySelector('[data-cmd="governor"]'), nearCity);
+   toggle(div.querySelector('[data-cmd="tavern"]'), nearCity);
+   toggle(div.querySelector('[data-cmd="upgrade"]'), nearCity);
   toggle(div.querySelector('[data-cmd="board"]'), nearEnemy);
   toggle(div.querySelector('[data-cmd="capture"]'), nearEnemy);
 }

--- a/pirates/ui/governor.js
+++ b/pirates/ui/governor.js
@@ -1,0 +1,45 @@
+import { bus } from '../bus.js';
+import { questManager } from '../questManager.js';
+import { Quest } from '../quest.js';
+import { updateHUD } from './hud.js';
+
+export function openGovernorMenu(player, city, metadata) {
+  const menu = document.getElementById('governorMenu');
+  if (!menu) return;
+  menu.innerHTML = '';
+
+  const title = document.createElement('div');
+  if (city?.name) title.textContent = `Governor of ${city.name}`;
+  menu.appendChild(title);
+
+  const nation = metadata?.nation || 'Unknown';
+  const rep = player.reputation?.[nation] || 0;
+  const repDiv = document.createElement('div');
+  repDiv.textContent = `Reputation with ${nation}: ${rep}`;
+  menu.appendChild(repDiv);
+
+  const missionBtn = document.createElement('button');
+  missionBtn.textContent = 'Accept mission';
+  missionBtn.onclick = () => {
+    const quest = new Quest('capture', 'Capture an enemy ship', nation, 10);
+    questManager.addQuest(quest);
+    bus.emit('log', 'Accepted mission from governor');
+    updateHUD(player);
+    menu.style.display = 'none';
+  };
+  menu.appendChild(missionBtn);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.onclick = () => {
+    menu.style.display = 'none';
+  };
+  menu.appendChild(closeBtn);
+
+  menu.style.display = 'block';
+}
+
+export function closeGovernorMenu() {
+  const menu = document.getElementById('governorMenu');
+  if (menu) menu.style.display = 'none';
+}

--- a/pirates/ui/tavern.js
+++ b/pirates/ui/tavern.js
@@ -1,0 +1,47 @@
+import { bus } from '../bus.js';
+import { updateHUD } from './hud.js';
+
+export function openTavernMenu(player, city) {
+  const menu = document.getElementById('tavernMenu');
+  if (!menu) return;
+  menu.innerHTML = '';
+
+  const title = document.createElement('div');
+  title.textContent = city?.name ? `Tavern in ${city.name}` : 'Tavern';
+  menu.appendChild(title);
+
+  const goldDiv = document.createElement('div');
+  goldDiv.textContent = `Gold: ${player.gold}`;
+  menu.appendChild(goldDiv);
+
+  const crewDiv = document.createElement('div');
+  crewDiv.textContent = `Crew: ${player.crew}`;
+  menu.appendChild(crewDiv);
+
+  const hireBtn = document.createElement('button');
+  hireBtn.textContent = 'Hire crew (20g)';
+  hireBtn.onclick = () => {
+    if (player.gold >= 20) {
+      player.gold -= 20;
+      player.crew += 1;
+      bus.emit('log', 'Hired 1 crew member for 20g');
+      updateHUD(player);
+      openTavernMenu(player, city);
+    }
+  };
+  menu.appendChild(hireBtn);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.onclick = () => {
+    menu.style.display = 'none';
+  };
+  menu.appendChild(closeBtn);
+
+  menu.style.display = 'block';
+}
+
+export function closeTavernMenu() {
+  const menu = document.getElementById('tavernMenu');
+  if (menu) menu.style.display = 'none';
+}

--- a/pirates/ui/upgrade.js
+++ b/pirates/ui/upgrade.js
@@ -1,0 +1,73 @@
+import { bus } from '../bus.js';
+import { updateHUD } from './hud.js';
+
+export function openUpgradeMenu(player) {
+  const menu = document.getElementById('upgradeMenu');
+  if (!menu) return;
+  menu.innerHTML = '';
+
+  const title = document.createElement('div');
+  title.textContent = 'Shipwright';
+  menu.appendChild(title);
+
+  const goldDiv = document.createElement('div');
+  goldDiv.textContent = `Gold: ${player.gold}`;
+  menu.appendChild(goldDiv);
+
+  const hullDiv = document.createElement('div');
+  hullDiv.textContent = `Hull: ${player.hull}/100`;
+  menu.appendChild(hullDiv);
+
+  const repairBtn = document.createElement('button');
+  repairBtn.textContent = 'Repair (10g for 10 hull)';
+  repairBtn.onclick = () => {
+    if (player.gold >= 10 && player.hull < 100) {
+      player.gold -= 10;
+      player.hull = Math.min(player.hull + 10, 100);
+      bus.emit('log', 'Repaired ship for 10g');
+      updateHUD(player);
+      openUpgradeMenu(player);
+    }
+  };
+  menu.appendChild(repairBtn);
+
+  const cargoBtn = document.createElement('button');
+  cargoBtn.textContent = 'Increase cargo (+10) - 50g';
+  cargoBtn.onclick = () => {
+    if (player.gold >= 50) {
+      player.gold -= 50;
+      player.cargoCapacity += 10;
+      bus.emit('log', 'Increased cargo capacity');
+      updateHUD(player);
+      openUpgradeMenu(player);
+    }
+  };
+  menu.appendChild(cargoBtn);
+
+  const cannonBtn = document.createElement('button');
+  cannonBtn.textContent = 'Improve cannons - 100g';
+  cannonBtn.onclick = () => {
+    if (player.gold >= 100) {
+      player.gold -= 100;
+      player.fireRate = Math.max(5, player.fireRate - 5);
+      bus.emit('log', 'Improved cannons');
+      updateHUD(player);
+      openUpgradeMenu(player);
+    }
+  };
+  menu.appendChild(cannonBtn);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.onclick = () => {
+    menu.style.display = 'none';
+  };
+  menu.appendChild(closeBtn);
+
+  menu.style.display = 'block';
+}
+
+export function closeUpgradeMenu() {
+  const menu = document.getElementById('upgradeMenu');
+  if (menu) menu.style.display = 'none';
+}


### PR DESCRIPTION
## Summary
- Implement governor, tavern, and upgrade UI modules with missions, crew recruitment, repairs, and ship upgrades
- Show new city interaction keys in command key panel
- Allow players to open city menus with hotkeys and close them when sailing away

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b743c61c6c832f89864b297559135d