### PR TITLE
Add morale and mutiny systems to ships

### DIFF
--- a/pirates/ui/hud.js
+++ b/pirates/ui/hud.js
@@ -24,6 +24,8 @@ export function updateHUD(player) {
     `Ship: (${player.x.toFixed(0)}, ${player.y.toFixed(0)})` +
     `<br>Gold: ${player.gold}` +
     `<br>Crew: ${player.crew}` +
+    `<br>Morale: ${player.morale.toFixed(0)}` +
+    `<br>Food: ${player.food.toFixed(0)}` +
     `<br>Cargo: ${cargoSummary(player)}` +
     `<br>Quests: ${quests}`;
 }


### PR DESCRIPTION
## Summary
- Track ship morale, food, and time at sea and allow loot distribution
- Reduce morale over voyages, restore at ports, and handle mutinies that can end the game
- Display morale and food in HUD

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b74676b9ac832f805030e5d0cae1e4