### PR TITLE
feat: add dynamic wind and sail controls

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -20,6 +20,9 @@ export class Ship {
     this.projectiles = [];
     this.reputation = {};
 
+    // sail control
+    this.sail = 1; // 0 = furled, 1 = full
+
     // supplies and crew management
     this.food = 100;
     this.morale = 100;
@@ -37,9 +40,19 @@ export class Ship {
   }
 
   forward(dt) {
+    const wind = Ship.wind || { speed: 0, angle: 0 };
+    const rel = wind.angle - this.angle;
+    const windAlong = Math.cos(rel) * wind.speed * this.sail;
+    const windSide = Math.sin(rel) * wind.speed * this.sail;
+    const forward = this.speed + windAlong;
+    const sideways = windSide;
     return {
-      x: Math.cos(this.angle) * this.speed * dt,
-      y: Math.sin(this.angle) * this.speed * dt
+      x:
+        Math.cos(this.angle) * forward * dt +
+        Math.cos(this.angle + Math.PI / 2) * sideways * dt,
+      y:
+        Math.sin(this.angle) * forward * dt +
+        Math.sin(this.angle + Math.PI / 2) * sideways * dt
     };
   }
 
@@ -100,6 +113,10 @@ export class Ship {
     if (Math.abs(this.speed) < 0.01) {
       this.speed = 0;
     }
+  }
+
+  setSail(state) {
+    this.sail = Math.max(0, Math.min(1, state));
   }
 
   draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {
@@ -173,6 +190,8 @@ export class Ship {
     this.reputation[nation] += amount;
   }
 }
+
+Ship.wind = { speed: 0, angle: 0 };
 
 function tileAt(tiles, x, y, gridSize) {
   const row = Math.floor(y / gridSize);

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -68,6 +68,15 @@ window.addEventListener('keyup', e => {
 const NATIONS = ['England', 'France', 'Spain', 'Netherlands'];
 const GOODS = ['Sugar', 'Rum', 'Tobacco', 'Cotton'];
 
+let wind = { speed: 0, angle: 0 };
+function updateWind() {
+  wind.speed = 0.5 + Math.random() * 2;
+  wind.angle = Math.random() * Math.PI * 2;
+}
+setInterval(updateWind, 10000);
+updateWind();
+Ship.wind = wind;
+
 function setup(seed=Math.random()) {
   const result = generateWorld(worldWidth, worldHeight, gridSize, seed);
   tiles = result.tiles;
@@ -143,11 +152,14 @@ function loop(timestamp) {
   if (keys['ArrowRight']) player.rotate(1);
   if (keys['ArrowUp']) player.speed = Math.min(player.speed + 0.1, 5);
   if (keys['ArrowDown']) player.speed = Math.max(player.speed - 0.1, 0);
+  if (keys['1']) { player.setSail(0); keys['1'] = false; }
+  if (keys['2']) { player.setSail(0.5); keys['2'] = false; }
+  if (keys['3']) { player.setSail(1); keys['3'] = false; }
   if (keys[' ']) player.fireCannons();
   player.update(dt, tiles, gridSize); // simplistic update with collision
 
   if (player.mutinied) {
-    updateHUD(player);
+    updateHUD(player, wind);
     return;
   }
 
@@ -210,7 +222,7 @@ function loop(timestamp) {
       i--;
     }
   }
-  updateHUD(player);
+  updateHUD(player, wind);
   drawMinimap(minimapCtx, tiles, player, worldWidth, worldHeight);
 
   const nearbyCity = cities.find(c => Math.hypot(player.x - c.x, player.y - c.y) < 32);

--- a/pirates/ui/commandKeys.js
+++ b/pirates/ui/commandKeys.js
@@ -8,6 +8,7 @@ export function initCommandKeys() {
     <div data-cmd="fire">Space: Fire cannon</div>
     <div data-cmd="pause">P: Pause/Unpause</div>
     <div data-cmd="minimap">M: Toggle minimap</div>
+    <div data-cmd="sails">1/2/3: Set sails (none/half/full)</div>
     <div data-cmd="trade" style="display:none">T: Trade (if near a city)</div>
     <div data-cmd="governor" style="display:none">G: Visit governor</div>
     <div data-cmd="tavern" style="display:none">V: Visit tavern</div>

--- a/pirates/ui/hud.js
+++ b/pirates/ui/hud.js
@@ -1,4 +1,5 @@
 import { questManager } from '../questManager.js';
+import { Ship } from '../entities/ship.js';
 
 export function initHUD() {
   const hudDiv = document.getElementById('hud');
@@ -13,13 +14,16 @@ function cargoSummary(player) {
   return `${used}/${player.cargoCapacity}${details ? ' (' + details + ')' : ''}`;
 }
 
-export function updateHUD(player) {
+export function updateHUD(player, wind) {
   const hudDiv = document.getElementById('hud');
   if (!hudDiv || !player) return;
   const quests = questManager
     .getActive()
     .map(q => q.description)
     .join('; ') || 'None';
+  const w = wind || Ship.wind || { speed: 0, angle: 0 };
+  const windDir = (w.angle * 180 / Math.PI).toFixed(0);
+  const windSpd = w.speed.toFixed(1);
   hudDiv.innerHTML =
     `Ship: (${player.x.toFixed(0)}, ${player.y.toFixed(0)})` +
     `<br>Gold: ${player.gold}` +
@@ -27,5 +31,7 @@ export function updateHUD(player) {
     `<br>Morale: ${player.morale.toFixed(0)}` +
     `<br>Food: ${player.food.toFixed(0)}` +
     `<br>Cargo: ${cargoSummary(player)}` +
+    `<br>Sails: ${(player.sail * 100).toFixed(0)}%` +
+    `<br>Wind: ${windSpd} @ ${windDir}&deg;` +
     `<br>Quests: ${quests}`;
 }


### PR DESCRIPTION
## Summary
- add periodically changing global wind vector and propagate to ships
- factor wind and sail state into ship movement
- show wind info on HUD and add sail control commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7479fcfa4832fac84fbe1bba5242e