### PR TITLE
Fix tile scaling in drawWorld

### DIFF
--- a/pirates/world.js
+++ b/pirates/world.js
@@ -127,7 +127,7 @@ export function drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight,
       else img = assets.tiles?.land;
       if (!img) continue;
       const { x, y } = worldToIso(r, c, tileWidth, tileIsoHeight, tileImageHeight, isoX, isoY);
-      ctx.drawImage(img, x, y, img.width, tileImageHeight);
+      ctx.drawImage(img, x, y, tileWidth, tileImageHeight);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Use the provided tileWidth when drawing world tiles to respect custom/scale overrides

## Testing
- `npm test`
- `node - <<'NODE'
import fs from 'fs';
import vm from 'vm';
let code = fs.readFileSync('./pirates/world.js','utf8');
code = code.replace(/import { createNoise2D }[^;]*;\n/,'');
code = code.replace(/import { assets } from '.\/assets.js';\n/,'');
code = code.replace(/export const Terrain =/,'globalThis.Terrain =');
code = code.replace(/export function generateWorld/,'globalThis.generateWorld = function');
code = code.replace(/export function worldToIso/,'globalThis.worldToIso = function');
code = code.replace(/export function cartToIso/,'globalThis.cartToIso = function');
code = code.replace(/export function drawWorld/,'globalThis.drawWorld = function');
vm.runInThisContext(code);
const tiles=[[Terrain.LAND]];
const assets={tiles:{land:{width:64,height:64},water:{width:64,height:64}}};
const calls=[];
const ctx={canvas:{clientWidth:128,clientHeight:128},drawImage:(img,x,y,w,h)=>{calls.push({w,h})}};
drawWorld(ctx,tiles,32,16,64,assets);
console.log(calls);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b7498c7ca8832fbd78c3261f85c991