### PR TITLE
Prevent default browser actions for game key presses

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -58,6 +58,9 @@ let tiles, player, cities, cityMetadata, npcShips;
 const keys = {};
 
 window.addEventListener('keydown', e => {
+  if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', ' '].includes(e.key)) {
+    e.preventDefault();
+  }
   keys[e.key] = true;
 });
 


### PR DESCRIPTION
## Summary
- Prevent browser defaults on arrow and space keys to keep focus on gameplay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b74a6da284832fa83901b72dae2c4c