### PR TITLE
Scale per-frame controls by delta time

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -109,7 +109,7 @@ export class Ship {
     this.y = newY;
 
     // Apply friction so ships gradually slow down
-    this.speed *= 0.98;
+    this.speed *= Math.pow(0.98, dt);
     if (Math.abs(this.speed) < 0.01) {
       this.speed = 0;
     }

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -151,10 +151,10 @@ function loop(timestamp) {
   const dt = (timestamp - lastTime) / 16;
   lastTime = timestamp;
   ctx.clearRect(0, 0, CSS_WIDTH, CSS_HEIGHT);
-  if (keys['ArrowLeft']) player.rotate(-1);
-  if (keys['ArrowRight']) player.rotate(1);
-  if (keys['ArrowUp']) player.speed = Math.min(player.speed + 0.1, 5);
-  if (keys['ArrowDown']) player.speed = Math.max(player.speed - 0.1, 0);
+  if (keys['ArrowLeft']) player.rotate(-dt);
+  if (keys['ArrowRight']) player.rotate(dt);
+  if (keys['ArrowUp']) player.speed = Math.min(player.speed + 0.1 * dt, 5);
+  if (keys['ArrowDown']) player.speed = Math.max(player.speed - 0.1 * dt, 0);
   if (keys['1']) { player.setSail(0); keys['1'] = false; }
   if (keys['2']) { player.setSail(0.5); keys['2'] = false; }
   if (keys['3']) { player.setSail(1); keys['3'] = false; }


### PR DESCRIPTION
## Summary
- Scale player rotation and acceleration with frame delta to ensure consistent controls
- Apply delta-based friction to ship movement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74bfaec58832fb2fcc273db6274e0