### PR TITLE
Scale projectiles by delta time

### DIFF
--- a/pirates/entities/projectile.js
+++ b/pirates/entities/projectile.js
@@ -9,10 +9,10 @@ export class Projectile {
     this.life = 120; // frames
   }
 
-  update() {
-    this.x += Math.cos(this.angle) * this.speed;
-    this.y += Math.sin(this.angle) * this.speed;
-    this.life--;
+  update(dt) {
+    this.x += Math.cos(this.angle) * this.speed * dt;
+    this.y += Math.sin(this.angle) * this.speed * dt;
+    this.life -= dt;
     return this.life > 0;
   }
 

--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -57,7 +57,7 @@ export class Ship {
   }
 
   update(dt, tiles, gridSize) {
-    this.projectiles = this.projectiles.filter(p => p.update());
+    this.projectiles = this.projectiles.filter(p => p.update(dt));
 
     if (this.fireCooldown > 0) {
       this.fireCooldown = Math.max(this.fireCooldown - dt, 0);


### PR DESCRIPTION
## Summary
- Update projectile movement and lifespan to scale with delta time
- Propagate delta time when updating projectiles in ships

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74d7f0be4832f9a4ff267da7a3dda