### PR TITLE
Use isometric offsets when drawing entities

### DIFF
--- a/pirates/entities/city.js
+++ b/pirates/entities/city.js
@@ -9,16 +9,24 @@ export class City {
   }
 
   draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {
+    const { isoX: offX, isoY: offY } = cartToIso(
+      offsetX,
+      offsetY,
+      tileWidth,
+      tileIsoHeight,
+      tileImageHeight
+    );
+
     const { isoX, isoY } = cartToIso(this.x, this.y, tileWidth, tileIsoHeight, tileImageHeight);
     const img = assets.tiles.village;
     if (img) {
       ctx.save();
-      ctx.translate(isoX - offsetX, isoY - offsetY);
+      ctx.translate(isoX - offX, isoY - offY);
       ctx.drawImage(img, -img.width / 2, -img.height / 2);
       ctx.restore();
     } else {
       ctx.fillStyle = 'gray';
-      ctx.fillRect(isoX - 8 - offsetX, isoY - 8 - offsetY, 16, 16);
+      ctx.fillRect(isoX - 8 - offX, isoY - 8 - offY, 16, 16);
     }
   }
 }

--- a/pirates/entities/projectile.js
+++ b/pirates/entities/projectile.js
@@ -17,9 +17,16 @@ export class Projectile {
   }
 
   draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {
+    const { isoX: offX, isoY: offY } = cartToIso(
+      offsetX,
+      offsetY,
+      tileWidth,
+      tileIsoHeight,
+      tileImageHeight
+    );
     const { isoX, isoY } = cartToIso(this.x, this.y, tileWidth, tileIsoHeight, tileImageHeight);
     ctx.save();
-    ctx.translate(isoX - offsetX, isoY - offsetY);
+    ctx.translate(isoX - offX, isoY - offY);
     ctx.fillStyle = 'black';
     ctx.beginPath();
     ctx.arc(0, 0, 2, 0, Math.PI * 2);

--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -120,23 +120,32 @@ export class Ship {
   }
 
   draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {
+    const { isoX: offX, isoY: offY } = cartToIso(
+      offsetX,
+      offsetY,
+      tileWidth,
+      tileIsoHeight,
+      tileImageHeight
+    );
+
     if (!this.sunk) {
       const img = assets.ship?.Sloop?.[this.nation] || assets.ship?.Sloop?.England;
+      const { isoX, isoY } = cartToIso(this.x, this.y, tileWidth, tileIsoHeight, tileImageHeight);
       if (img) {
-        const { isoX, isoY } = cartToIso(this.x, this.y, tileWidth, tileIsoHeight, tileImageHeight);
         ctx.save();
-        ctx.translate(isoX - offsetX, isoY - offsetY);
+        ctx.translate(isoX - offX, isoY - offY);
         ctx.rotate(this.angle);
         ctx.drawImage(img, -img.width / 2, -img.height / 2);
         ctx.restore();
       } else {
-        const { isoX, isoY } = cartToIso(this.x, this.y, tileWidth, tileIsoHeight, tileImageHeight);
         ctx.fillStyle = 'brown';
-        ctx.fillRect(isoX - 5 - offsetX, isoY - 5 - offsetY, 10, 10);
+        ctx.fillRect(isoX - 5 - offX, isoY - 5 - offY, 10, 10);
       }
     }
 
-    this.projectiles.forEach(p => p.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight));
+    this.projectiles.forEach(p =>
+      p.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight)
+    );
   }
 
   fireCannons() {


### PR DESCRIPTION
## Summary
- Convert camera offsets to isometric coordinates in ship, city, and projectile draws
- Translate using isometric offsets and adjust fallback drawing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7549ef0a0832fb9f789fb91a56e2b