### PR TITLE
Refactor boarding into async loop

### DIFF
--- a/pirates/boarding.js
+++ b/pirates/boarding.js
@@ -8,53 +8,66 @@ export function startBoarding(player, enemy) {
 
   let playerCrew = player.crew;
   let enemyCrew = enemy.crew;
+  const logs = [];
 
-  // Simple combat loop
-  while (playerCrew > 0 && enemyCrew > 0) {
-    const playerRoll = Math.random() * playerCrew;
-    const enemyRoll = Math.random() * enemyCrew;
-    if (playerRoll > enemyRoll) {
-      enemyCrew--;
-      bus.emit('log', `Enemy loses a crew member (${enemyCrew} left)`);
-    } else {
-      playerCrew--;
-      bus.emit('log', `You lose a crew member (${playerCrew} left)`);
+  function flushLogs() {
+    if (logs.length) {
+      bus.emit('log', logs.slice());
+      logs.length = 0;
     }
   }
 
-  player.crew = playerCrew;
-  enemy.crew = enemyCrew;
-
-  if (playerCrew > 0) {
-    bus.emit('log', `You captured the ${enemy.nation} ship!`);
-
-    // Transfer gold and cargo
-    if (enemy.gold) {
-      player.gold += enemy.gold;
-      bus.emit('log', `Plundered ${enemy.gold} gold`);
-    }
-
-    if (enemy.cargo) {
-      let used = Object.values(player.cargo).reduce((a, b) => a + b, 0);
-      const capacity = player.cargoCapacity;
-      for (const [good, qty] of Object.entries(enemy.cargo)) {
-        const space = capacity - used;
-        if (space <= 0) break;
-        const add = Math.min(qty, space);
-        player.cargo[good] = (player.cargo[good] || 0) + add;
-        used += add;
-        bus.emit('log', `Seized ${add} ${good}`);
+  function tick() {
+    if (playerCrew > 0 && enemyCrew > 0) {
+      const playerRoll = Math.random() * playerCrew;
+      const enemyRoll = Math.random() * enemyCrew;
+      if (playerRoll > enemyRoll) {
+        enemyCrew--;
+        logs.push(`Enemy loses a crew member (${enemyCrew} left)`);
+      } else {
+        playerCrew--;
+        logs.push(`You lose a crew member (${playerCrew} left)`);
       }
+      flushLogs();
+      requestAnimationFrame(tick);
+    } else {
+      player.crew = playerCrew;
+      enemy.crew = enemyCrew;
+
+      if (playerCrew > 0) {
+        logs.push(`You captured the ${enemy.nation} ship!`);
+
+        if (enemy.gold) {
+          player.gold += enemy.gold;
+          logs.push(`Plundered ${enemy.gold} gold`);
+        }
+
+        if (enemy.cargo) {
+          let used = Object.values(player.cargo).reduce((a, b) => a + b, 0);
+          const capacity = player.cargoCapacity;
+          for (const [good, qty] of Object.entries(enemy.cargo)) {
+            const space = capacity - used;
+            if (space <= 0) break;
+            const add = Math.min(qty, space);
+            player.cargo[good] = (player.cargo[good] || 0) + add;
+            used += add;
+            logs.push(`Seized ${add} ${good}`);
+          }
+        }
+
+        player.adjustReputation(enemy.nation, -5);
+        logs.push(`Reputation with ${enemy.nation} decreased`);
+
+        enemy.sunk = true;
+      } else {
+        logs.push('Boarding failed! Your crew was repelled.');
+        player.adjustReputation(enemy.nation, -1);
+      }
+
+      flushLogs();
+      updateHUD(player);
     }
-
-    player.adjustReputation(enemy.nation, -5);
-    bus.emit('log', `Reputation with ${enemy.nation} decreased`);
-
-    enemy.sunk = true;
-  } else {
-    bus.emit('log', 'Boarding failed! Your crew was repelled.');
-    player.adjustReputation(enemy.nation, -1);
   }
 
-  updateHUD(player);
+  requestAnimationFrame(tick);
 }

--- a/pirates/ui/log.js
+++ b/pirates/ui/log.js
@@ -2,9 +2,12 @@ export function initLog(bus) {
   const logDiv = document.getElementById('log');
   if (!logDiv || !bus) return;
   bus.on('log', msg => {
-    const div = document.createElement('div');
-    div.textContent = msg;
-    logDiv.appendChild(div);
+    const messages = Array.isArray(msg) ? msg : [msg];
+    for (const m of messages) {
+      const div = document.createElement('div');
+      div.textContent = m;
+      logDiv.appendChild(div);
+    }
     logDiv.scrollTop = logDiv.scrollHeight;
   });
 }


### PR DESCRIPTION
## Summary
- Run boarding combat in an asynchronous loop using requestAnimationFrame
- Batch combat log messages per frame to avoid DOM floods
- Update UI log handler to accept arrays of messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7555a4488832f82dc2de0fc4638de