### PR TITLE
Handle cities with missing nation data

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -120,8 +120,8 @@ function setup(seed=Math.random()) {
 
     const supplies = GOODS.filter(() => rand() < 0.5);
     const demands = GOODS.filter(g => !supplies.includes(g) && rand() < 0.5);
-    // nation will be assigned after all cities are created
-    cityMetadata.set(city, { nation: null, supplies, demands });
+    // Assign a default nation; it will be overwritten below
+    cityMetadata.set(city, { nation: 'Unknown', supplies, demands });
   });
 
   // Deterministically shuffle cities for nation assignment
@@ -143,8 +143,8 @@ function setup(seed=Math.random()) {
     } else {
       nation = NATIONS[Math.floor(rand() * NATIONS.length)];
     }
-    const metadata = cityMetadata.get(city);
-    metadata.nation = nation;
+    const metadata = cityMetadata.get(city) || { supplies: [], demands: [], nation: 'Unknown' };
+    metadata.nation = nation || metadata.nation || 'Unknown';
     cityMetadata.set(city, metadata);
   });
 

--- a/pirates/ui/governor.js
+++ b/pirates/ui/governor.js
@@ -6,13 +6,19 @@ import { updateHUD } from './hud.js';
 export function openGovernorMenu(player, city, metadata) {
   const menu = document.getElementById('governorMenu');
   if (!menu) return;
+
+  if (!metadata?.nation) {
+    bus.emit('log', `Cannot open governor menu for ${city?.name || 'unknown city'}: nation unknown`);
+    return;
+  }
+
   menu.innerHTML = '';
 
   const title = document.createElement('div');
   if (city?.name) title.textContent = `Governor of ${city.name}`;
   menu.appendChild(title);
 
-  const nation = metadata?.nation || 'Unknown';
+  const nation = metadata.nation;
   const rep = player.reputation?.[nation] || 0;
   const repDiv = document.createElement('div');
   repDiv.textContent = `Reputation with ${nation}: ${rep}`;

--- a/pirates/ui/trade.js
+++ b/pirates/ui/trade.js
@@ -24,6 +24,12 @@ function cargoUsed(player) {
 export function openTradeMenu(player, city, metadata) {
   const menu = document.getElementById('tradeMenu');
   if (!menu || !player) return;
+
+  if (!metadata?.nation) {
+    bus.emit('log', `Cannot open trade menu for ${city?.name || 'unknown city'}: nation unknown`);
+    return;
+  }
+
   menu.innerHTML = '';
 
   const title = document.createElement('div');


### PR DESCRIPTION
## Summary
- Default new city metadata to `Unknown` nation during world setup and ensure nation is always defined
- Avoid opening trade and governor menus when a city's nation data is missing and log a diagnostic message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7b49507e8832fa85405b52cb3f223