### PR TITLE
Add slow down command key

### DIFF
--- a/pirates/ui/commandKeys.js
+++ b/pirates/ui/commandKeys.js
@@ -4,6 +4,7 @@ export function initCommandKeys() {
   div.innerHTML = `
     <strong>Command Keys:</strong>
     <div data-cmd="move">&uarr; : Move forward</div>
+    <div data-cmd="slow">&darr; : Slow down</div>
     <div data-cmd="rotate">&larr; / &rarr; : Rotate ship</div>
     <div data-cmd="fire">Space: Fire cannon</div>
     <div data-cmd="pause">P: Pause/Unpause</div>


### PR DESCRIPTION
## Summary
- Display new down-arrow key for slowing down
- Group up/down movement keys before rotation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b74dbfe0832fbe3eaa10e3148556