### PR TITLE
Track city inventories and adjust trade prices

### DIFF
--- a/pirates/ui/trade.js
+++ b/pirates/ui/trade.js
@@ -11,10 +11,14 @@ function listGoods(metadata) {
 }
 
 function priceFor(good, metadata) {
-  let price = PRICES[good];
-  if (metadata?.supplies?.includes(good)) price = Math.round(price * 0.8);
-  if (metadata?.demands?.includes(good)) price = Math.round(price * 1.2);
-  return price;
+  metadata.prices = metadata.prices || {};
+  if (metadata.prices[good] == null) {
+    let price = PRICES[good];
+    if (metadata?.supplies?.includes(good)) price = Math.round(price * 0.8);
+    if (metadata?.demands?.includes(good)) price = Math.round(price * 1.2);
+    metadata.prices[good] = price;
+  }
+  return metadata.prices[good];
 }
 
 function cargoUsed(player) {
@@ -46,22 +50,31 @@ export function openTradeMenu(player, city, metadata) {
 
   const table = document.createElement('table');
   const header = document.createElement('tr');
-  header.innerHTML = '<th>Good</th><th>Qty</th><th>Price</th><th></th><th></th>';
+  header.innerHTML = '<th>Good</th><th>Qty</th><th>Stock</th><th>Price</th><th></th><th></th>';
   table.appendChild(header);
 
+  metadata.inventory = metadata.inventory || {};
   listGoods(metadata).forEach(good => {
     const row = document.createElement('tr');
     const qty = player.cargo[good] || 0;
+    if (metadata.inventory[good] == null) metadata.inventory[good] = 10;
+    const stock = metadata.inventory[good];
     const price = priceFor(good, metadata);
-    row.innerHTML = `<td>${good}</td><td>${qty}</td><td>${price}g</td>`;
+    row.innerHTML = `<td>${good}</td><td>${qty}</td><td>${stock}</td><td>${price}g</td>`;
 
     const buyCell = document.createElement('td');
     const buyBtn = document.createElement('button');
     buyBtn.textContent = 'Buy';
     buyBtn.onclick = () => {
-      if (player.gold >= price && cargoUsed(player) < player.cargoCapacity) {
+      if (
+        player.gold >= price &&
+        cargoUsed(player) < player.cargoCapacity &&
+        metadata.inventory[good] > 0
+      ) {
         player.gold -= price;
         player.cargo[good] = (player.cargo[good] || 0) + 1;
+        metadata.inventory[good] -= 1;
+        metadata.prices[good] = Math.round(metadata.prices[good] * 1.1);
         bus.emit('log', `Bought 1 ${good} for ${price}g`);
         updateHUD(player);
         openTradeMenu(player, city, metadata);
@@ -77,6 +90,8 @@ export function openTradeMenu(player, city, metadata) {
       if ((player.cargo[good] || 0) > 0) {
         player.cargo[good] -= 1;
         player.gold += price;
+        metadata.inventory[good] += 1;
+        metadata.prices[good] = Math.max(1, Math.round(metadata.prices[good] * 0.9));
         bus.emit('log', `Sold 1 ${good} for ${price}g`);
         updateHUD(player);
         openTradeMenu(player, city, metadata);


### PR DESCRIPTION
## Summary
- Track per-city good inventories and dynamic prices
- Adjust stock and price based on buying and selling
- Show available stock in trade menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7b89a96d8832fb3f817e1989ac908