### PR TITLE
feat: enhance npc firing logic

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -261,8 +261,7 @@ function loop(timestamp) {
   cities.forEach(c => c.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight));
   npcShips.forEach(n => {
     n.update(dt, tiles, gridSize, player);
-    const dist = Math.hypot(player.x - n.x, player.y - n.y);
-    if (dist < 200) n.fireCannons();
+    n.fireCannons(player);
     n.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight);
   });
   player.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight);


### PR DESCRIPTION
## Summary
- allow tuning of NPC firing range and accuracy
- NPC ships predict player movement to lead shots
- centralize NPC firing logic with cooldown and facing checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7bae41df8832f86e6391855f5f255