### PR TITLE
Add hull health display to HUD

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -15,7 +15,8 @@ export class Ship {
     this.cargoCapacity = 20;
     this.gold = 100;
     this.crew = 10;
-    this.hull = 100;
+    this.hullMax = 100;
+    this.hull = this.hullMax;
     this.sunk = false;
     this.projectiles = [];
     this.reputation = {};

--- a/pirates/index.html
+++ b/pirates/index.html
@@ -36,6 +36,10 @@
       padding: 5px;
       font-size: 14px;
     }
+    #hud progress {
+      width: 100px;
+      height: 10px;
+    }
     /* Quest log panel positioned below the minimap */
     #questLog {
       position: absolute;

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -187,6 +187,7 @@ function saveGame() {
       gold: player.gold,
       crew: player.crew,
       hull: player.hull,
+      hullMax: player.hullMax,
       cargo: player.cargo,
       reputation: player.reputation
     }

--- a/pirates/ui/hud.js
+++ b/pirates/ui/hud.js
@@ -28,6 +28,8 @@ export function updateHUD(player, wind) {
     `Ship: (${player.x.toFixed(0)}, ${player.y.toFixed(0)})` +
     `<br>Gold: ${player.gold}` +
     `<br>Crew: ${player.crew}` +
+    `<br>Hull: ${player.hull}/${player.hullMax}` +
+    `<br><progress value="${player.hull}" max="${player.hullMax}"></progress>` +
     `<br>Morale: ${player.morale.toFixed(0)}` +
     `<br>Food: ${player.food.toFixed(0)}` +
     `<br>Cargo: ${cargoSummary(player)}` +

--- a/pirates/ui/upgrade.js
+++ b/pirates/ui/upgrade.js
@@ -15,15 +15,15 @@ export function openUpgradeMenu(player) {
   menu.appendChild(goldDiv);
 
   const hullDiv = document.createElement('div');
-  hullDiv.textContent = `Hull: ${player.hull}/100`;
+  hullDiv.textContent = `Hull: ${player.hull}/${player.hullMax}`;
   menu.appendChild(hullDiv);
 
   const repairBtn = document.createElement('button');
   repairBtn.textContent = 'Repair (10g for 10 hull)';
   repairBtn.onclick = () => {
-    if (player.gold >= 10 && player.hull < 100) {
+    if (player.gold >= 10 && player.hull < player.hullMax) {
       player.gold -= 10;
-      player.hull = Math.min(player.hull + 10, 100);
+      player.hull = Math.min(player.hull + 10, player.hullMax);
       bus.emit('log', 'Repaired ship for 10g');
       updateHUD(player);
       openUpgradeMenu(player);


### PR DESCRIPTION
## Summary
- Show hull HP (current/max) and a progress bar in HUD
- Add hullMax property to Ship and update repair UI
- Save hullMax in game state for persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7bba63070832f812abd572c34ac1a