### PR TITLE
feat: centralize camera offset for centered ship

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -87,6 +87,13 @@ setInterval(updateWind, 10000);
 updateWind();
 Ship.wind = wind;
 
+function getCameraOffset(player) {
+  return {
+    x: player.x - CSS_WIDTH / 2,
+    y: player.y - CSS_HEIGHT / 2
+  };
+}
+
 function setup(seed = currentSeed) {
   currentSeed = seed;
   const result = generateWorld(worldWidth, worldHeight, gridSize, seed);
@@ -255,8 +262,7 @@ function loop(timestamp) {
     return;
   }
 
-  const offsetX = player.x - CSS_WIDTH / 2;
-  const offsetY = player.y - CSS_HEIGHT / 2;
+  const { x: offsetX, y: offsetY } = getCameraOffset(player);
 
   drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight, assets, offsetX, offsetY);
   cities.forEach(c => c.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight));


### PR DESCRIPTION
## Summary
- add helper to compute camera offset from player position
- use shared offset to draw world and entities relative to player center

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7bf3d5b24832fbb5767358fffed61