### PR TITLE
Introduce ship classes and capture swapping

### DIFF
--- a/pirates/assets.json
+++ b/pirates/assets.json
@@ -7,18 +7,21 @@
   },
   "ship": {
     "Sloop": {
+      "Pirate": "assets/slopTB128.png",
       "Netherlands": "assets/slopTB128.png",
       "Spain": "assets/slopTB128.png",
       "France": "assets/slopTB128.png",
       "England": "assets/slopTB128.png"
     },
     "Brig": {
+      "Pirate": "assets/brigTB128.png",
       "Netherlands":  "assets/brigTB128.png",
       "Spain": "assets/brigTB128.png",
       "France": "assets/brigTB128.png",
       "England": "assets/brigTB128.png"
     },
     "Galleon": {
+      "Pirate": "assets/galleonTB128.png",
       "Netherlands": "assets/galleonTB128.png",
       "Spain": "assets/galleonTB128.png",
       "France": "assets/galleonTB128.png",

--- a/pirates/boarding.js
+++ b/pirates/boarding.js
@@ -57,6 +57,14 @@ export function startBoarding(player, enemy) {
 
         player.adjustReputation(enemy.nation, -5);
         logs.push(`Reputation with ${enemy.nation} decreased`);
+        flushLogs();
+        if (confirm(`Take the captured ${enemy.type || 'ship'}?`)) {
+          player.changeType(enemy.type);
+          player.hull = Math.min(enemy.hull, player.hullMax);
+          logs.push(`You now command the ${enemy.type}`);
+        } else {
+          logs.push('You keep your current ship.');
+        }
 
         enemy.sunk = true;
       } else {

--- a/pirates/entities/npcShip.js
+++ b/pirates/entities/npcShip.js
@@ -9,8 +9,8 @@ export const npcDifficulty = {
 };
 
 export class NpcShip extends Ship {
-  constructor(x, y, nation = 'Pirate', difficulty = npcDifficulty) {
-    super(x, y, nation);
+  constructor(x, y, nation = 'Pirate', type = 'Sloop', difficulty = npcDifficulty) {
+    super(x, y, nation, type);
     this.state = 'patrol';
     this.detectRadius = 300;
     this.fleeRadius = 80;

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -172,7 +172,11 @@ function setup(seed = currentSeed) {
     const { r, c } = waterTiles[idx];
     const x = c * gridSize + gridSize / 2;
     const y = r * gridSize + gridSize / 2;
-    npcShips.push(new NpcShip(x, y, NATIONS[Math.floor(rand() * NATIONS.length)]));
+    const typeNames = Object.keys(Ship.TYPES);
+    const type = typeNames[Math.floor(rand() * typeNames.length)];
+    npcShips.push(
+      new NpcShip(x, y, NATIONS[Math.floor(rand() * NATIONS.length)], type)
+    );
   }
 
   questManager.addQuest(new Quest('capture', 'Capture an enemy ship', 'England', 10));
@@ -194,6 +198,9 @@ function saveGame() {
       y: player.y,
       speed: player.speed,
       angle: player.angle,
+      type: player.type,
+      maxSpeed: player.maxSpeed,
+      cargoCapacity: player.cargoCapacity,
       gold: player.gold,
       crew: player.crew,
       hull: player.hull,
@@ -252,7 +259,7 @@ function loop(timestamp) {
   ctx.clearRect(0, 0, CSS_WIDTH, CSS_HEIGHT);
   if (keys['ArrowLeft']) player.rotate(-dt);
   if (keys['ArrowRight']) player.rotate(dt);
-  if (keys['ArrowUp']) player.speed = Math.min(player.speed + 0.1 * dt, 5);
+  if (keys['ArrowUp']) player.speed = Math.min(player.speed + 0.1 * dt, player.maxSpeed);
   if (keys['ArrowDown']) player.speed = Math.max(player.speed - 0.1 * dt, 0);
   if (keys['1']) { player.setSail(0); keys['1'] = false; }
   if (keys['2']) { player.setSail(0.5); keys['2'] = false; }

--- a/pirates/ui/upgrade.js
+++ b/pirates/ui/upgrade.js
@@ -1,5 +1,6 @@
 import { bus } from '../bus.js';
 import { updateHUD } from './hud.js';
+import { Ship } from '../entities/ship.js';
 
 export function openUpgradeMenu(player) {
   const menu = document.getElementById('upgradeMenu');
@@ -17,6 +18,10 @@ export function openUpgradeMenu(player) {
   const hullDiv = document.createElement('div');
   hullDiv.textContent = `Hull: ${player.hull}/${player.hullMax}`;
   menu.appendChild(hullDiv);
+
+  const typeDiv = document.createElement('div');
+  typeDiv.textContent = `Ship: ${player.type}`;
+  menu.appendChild(typeDiv);
 
   const repairBtn = document.createElement('button');
   repairBtn.textContent = 'Repair (10g for 10 hull)';
@@ -56,6 +61,26 @@ export function openUpgradeMenu(player) {
     }
   };
   menu.appendChild(cannonBtn);
+
+  const shipTitle = document.createElement('div');
+  shipTitle.textContent = 'Buy new ship:';
+  menu.appendChild(shipTitle);
+
+  Object.entries(Ship.TYPES).forEach(([type, stats]) => {
+    if (type === player.type) return;
+    const btn = document.createElement('button');
+    btn.textContent = `${type} - ${stats.cost}g`;
+    btn.onclick = () => {
+      if (player.gold >= stats.cost) {
+        player.gold -= stats.cost;
+        player.changeType(type);
+        bus.emit('log', `Upgraded to a ${type}`);
+        updateHUD(player);
+        openUpgradeMenu(player);
+      }
+    };
+    menu.appendChild(btn);
+  });
 
   const closeBtn = document.createElement('button');
   closeBtn.textContent = 'Close';


### PR DESCRIPTION
## Summary
- Add ship class system with default stats and assets per nation
- Allow upgrading to new ship types and capturing ships in boarding
- Extend save data and asset manifest to support ship classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88d73a2f4832fbcd0ec1a89bd2740