### PR TITLE
Log when trade menu opens

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -434,6 +434,7 @@ function loop(timestamp) {
           bus.emit('log', `${nation} merchants levy a surcharge due to your reputation.`);
         }
         openTradeMenu(player, nearbyCity, metadata, multiplier);
+        bus.emit('log', `Opened trade with ${nearbyCity.name}`);
       }
       keys['t'] = keys['T'] = false;
     }


### PR DESCRIPTION
## Summary
- Log when a player opens the trade menu to know which city is involved

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b895c05428832fb24a5cce6d2419df