### PR TITLE
Log approaching city when entering port

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -417,7 +417,10 @@ function loop(timestamp) {
 
   const nearbyCity = cities.find(c => Math.hypot(player.x - c.x, player.y - c.y) < 32);
   if (nearbyCity) {
-    if (!player.inPort) player.visitPort();
+    if (!player.inPort) {
+      bus.emit('log', `Approaching ${nearbyCity.name}`);
+      player.visitPort();
+    }
   } else {
     player.inPort = false;
   }


### PR DESCRIPTION
## Summary
- Emit log message when the player's ship comes within range of a city
- Only log once per approach before entering port

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b909afa540832fb9dd7c618a903673