### PR TITLE
Treat out-of-bounds tiles as water and test ship movement

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Sharing games generated via language models",
   "scripts": {
-    "test": "echo 'No tests'",
+    "test": "node --test",
     "start": "node server.js"
   },
   "keywords": [],

--- a/pirates/bus.js
+++ b/pirates/bus.js
@@ -1,3 +1,9 @@
-import mitt from 'https://cdn.jsdelivr.net/npm/mitt@3.0.1/+esm'
- 
+// Attempt to import mitt locally for Node environments; fall back to CDN for browsers.
+let mitt;
+try {
+  ({ default: mitt } = await import('mitt'));
+} catch {
+  ({ default: mitt } = await import('https://cdn.jsdelivr.net/npm/mitt@3.0.1/+esm'));
+}
+
 export const bus = mitt();

--- a/pirates/world.js
+++ b/pirates/world.js
@@ -1,5 +1,12 @@
-import { createNoise2D } from 'https://cdn.skypack.dev/simplex-noise';
 import { assets } from './assets.js';
+
+// Attempt to import simplex-noise locally for Node environments; fall back to CDN for browsers.
+let createNoise2D;
+try {
+  ({ createNoise2D } = await import('simplex-noise'));
+} catch {
+  ({ createNoise2D } = await import('https://cdn.skypack.dev/simplex-noise'));
+}
 
 export const Terrain = {
   WATER: 0,
@@ -167,7 +174,7 @@ export function tileAt(tiles, x, y, gridSize) {
   const row = Math.floor(y / gridSize);
   const col = Math.floor(x / gridSize);
   if (row < 0 || row >= tiles.length || col < 0 || col >= tiles[0].length) {
-    return Terrain.LAND;
+    return Terrain.WATER;
   }
   return tiles[row][col];
 }

--- a/test/world.test.js
+++ b/test/world.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { tileAt, Terrain } from '../pirates/world.js';
+import { Ship } from '../pirates/entities/ship.js';
+
+// Helper tiles: single water tile
+const waterTiles = [[Terrain.WATER]];
+const gridSize = 10;
+
+test('tileAt returns water for out-of-bounds coordinates', () => {
+  assert.equal(tileAt(waterTiles, -1, 0, gridSize), Terrain.WATER);
+  assert.equal(tileAt(waterTiles, 0, -1, gridSize), Terrain.WATER);
+  assert.equal(tileAt(waterTiles, gridSize + 1, 0, gridSize), Terrain.WATER);
+  assert.equal(tileAt(waterTiles, 0, gridSize + 1, gridSize), Terrain.WATER);
+});
+
+test('ship can move beyond grid without collision', () => {
+  const ship = new Ship(5, 5);
+  ship.speed = 10; // move east fast enough to leave the grid
+  ship.angle = 0; // east
+  ship.update(1, waterTiles, gridSize);
+  assert.ok(ship.x > gridSize, `Ship did not move beyond grid: ${ship.x}`);
+});


### PR DESCRIPTION
## Summary
- Ensure `tileAt` returns water when coordinates fall outside the grid and add Node-friendly imports for testing
- Provide local fallback imports for `simplex-noise` and `mitt`
- Add tests verifying `tileAt` and ship movement beyond the map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99b2d1980832faec4775b64a34738