### PR TITLE
Avoid subpixel blur when drawing world tiles

### DIFF
--- a/pirates/world.js
+++ b/pirates/world.js
@@ -237,7 +237,7 @@ export function drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight,
       else img = assets.tiles?.land;
       if (!img) continue;
       const { x, y } = worldToIso(r, c, tileWidth, tileIsoHeight, tileImageHeight, isoX, isoY);
-      ctx.drawImage(img, x, y, tileWidth, tileImageHeight);
+      ctx.drawImage(img, Math.round(x), Math.round(y), tileWidth, tileImageHeight);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Round tile draw coordinates in `drawWorld` to prevent subpixel blurring.

## Testing
- `npm test`
- `npm start` (manually verified server runs)

------
https://chatgpt.com/codex/tasks/task_e_68b9a288a3bc832f9a4d79e27fbd187b