### PR TITLE
Use Terrain constant in minimap

### DIFF
--- a/pirates/ui/minimap.js
+++ b/pirates/ui/minimap.js
@@ -1,3 +1,5 @@
+import { Terrain } from '../world.js';
+
 export function initMinimap() {
   // nothing needed for now
 }
@@ -12,7 +14,7 @@ export function drawMinimap(ctx, tiles, player, worldWidth, worldHeight) {
   ctx.fillStyle = '#070';
   for (let r = 0; r < tiles.length; r++) {
     for (let c = 0; c < tiles[0].length; c++) {
-      if (tiles[r][c] !== 0) {
+      if (tiles[r][c] !== Terrain.WATER) {
         const x = c / tiles[0].length * width;
         const y = r / tiles.length * height;
         ctx.fillRect(x, y, width / tiles[0].length, height / tiles.length);

--- a/test/minimap.test.js
+++ b/test/minimap.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { drawMinimap } from '../pirates/ui/minimap.js';
+import { Terrain } from '../pirates/world.js';
+
+test('minimap uses Terrain.WATER constant', () => {
+  const originalWater = Terrain.WATER;
+  try {
+    Terrain.WATER = 9;
+    const tiles = [[9]];
+    const calls = [];
+    const ctx = {
+      canvas: { width: 10, height: 10 },
+      clearRect() {},
+      fillStyle: '',
+      fillRect(x, y, w, h) {
+        calls.push({ x, y, w, h, fillStyle: this.fillStyle });
+      }
+    };
+    drawMinimap(ctx, tiles, null, 10, 10);
+    assert.equal(calls.length, 1);
+  } finally {
+    Terrain.WATER = originalWater;
+  }
+});
+
+test('minimap draws land tiles', () => {
+  const tiles = [[Terrain.LAND]];
+  const calls = [];
+  const ctx = {
+    canvas: { width: 10, height: 10 },
+    clearRect() {},
+    fillStyle: '',
+    fillRect(x, y, w, h) {
+      calls.push({ x, y, w, h, fillStyle: this.fillStyle });
+    }
+  };
+  drawMinimap(ctx, tiles, null, 10, 10);
+  assert.equal(calls.length, 2);
+});


### PR DESCRIPTION
## Summary
- import Terrain in minimap and render land tiles based on Terrain.WATER
- add tests ensuring minimap respects Terrain definitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a4039d94832f97c2a945b5fa79e7