### PR TITLE
Clamp ship movement to world bounds

### DIFF
--- a/pirates/entities/npcShip.js
+++ b/pirates/entities/npcShip.js
@@ -20,7 +20,7 @@ export class NpcShip extends Ship {
     this.accuracy = difficulty.accuracy;
   }
 
-  update(dt, tiles, gridSize, player) {
+  update(dt, tiles, gridSize, player, worldWidth, worldHeight) {
     const dist = Math.hypot(player.x - this.x, player.y - this.y);
     const relation = bus.getRelation
       ? bus.getRelation(this.nation, player.nation)
@@ -71,7 +71,7 @@ export class NpcShip extends Ship {
         break;
     }
 
-    super.update(dt, tiles, gridSize);
+    super.update(dt, tiles, gridSize, worldWidth, worldHeight);
   }
 
   fireCannons(target) {

--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -66,7 +66,7 @@ export class Ship {
     };
   }
 
-  update(dt, tiles, gridSize) {
+  update(dt, tiles, gridSize, worldWidth, worldHeight) {
     this.projectiles = this.projectiles.filter(p => p.update(dt));
 
     if (this.fireCooldown > 0) {
@@ -102,21 +102,23 @@ export class Ship {
           tileX !== Terrain.HILL &&
           tileX !== Terrain.VILLAGE
         ) {
-          this.x += dx;
+          this.x = Math.max(0, Math.min(this.x + dx, worldWidth));
         } else if (
           tileY !== Terrain.LAND &&
           tileY !== Terrain.COAST &&
           tileY !== Terrain.HILL &&
           tileY !== Terrain.VILLAGE
         ) {
-          this.y += dy;
+          this.y = Math.max(0, Math.min(this.y + dy, worldHeight));
         }
+        this.x = Math.max(0, Math.min(this.x, worldWidth));
+        this.y = Math.max(0, Math.min(this.y, worldHeight));
         return;
       }
     }
 
-    this.x = newX;
-    this.y = newY;
+    this.x = Math.max(0, Math.min(newX, worldWidth));
+    this.y = Math.max(0, Math.min(newY, worldHeight));
 
     // Apply friction so ships gradually slow down
     this.speed *= Math.pow(0.98, dt);

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -346,7 +346,7 @@ function loop(timestamp) {
   if (keys['2']) { player.setSail(0.5); keys['2'] = false; }
   if (keys['3']) { player.setSail(1); keys['3'] = false; }
   if (keys[' ']) player.fireCannons();
-  player.update(dt, tiles, gridSize); // simplistic update with collision
+  player.update(dt, tiles, gridSize, worldWidth, worldHeight); // simplistic update with collision
 
   if (player.mutinied) {
     updateHUD(player, wind);
@@ -358,7 +358,7 @@ function loop(timestamp) {
   drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight, assets, offsetX, offsetY);
   cities.forEach(c => c.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight));
   npcShips.forEach(n => {
-    n.update(dt, tiles, gridSize, player);
+    n.update(dt, tiles, gridSize, player, worldWidth, worldHeight);
     n.fireCannons(player);
     n.draw(ctx, offsetX, offsetY, tileWidth, tileIsoHeight, tileImageHeight);
   });

--- a/test/world.test.js
+++ b/test/world.test.js
@@ -14,10 +14,36 @@ test('tileAt returns water for out-of-bounds coordinates', () => {
   assert.equal(tileAt(waterTiles, 0, gridSize + 1, gridSize), Terrain.WATER);
 });
 
-test('ship can move beyond grid without collision', () => {
-  const ship = new Ship(5, 5);
-  ship.speed = 10; // move east fast enough to leave the grid
+test('ship is clamped within world bounds', () => {
+  const ship = new Ship(50, 50);
+  const worldWidth = 100;
+  const worldHeight = 100;
+
+  // move west beyond 0
+  ship.speed = 100;
+  ship.angle = Math.PI; // west
+  ship.update(1, waterTiles, gridSize, worldWidth, worldHeight);
+  assert.equal(ship.x, 0);
+
+  // move east beyond width
+  ship.x = 95;
+  ship.speed = 100;
   ship.angle = 0; // east
-  ship.update(1, waterTiles, gridSize);
-  assert.ok(ship.x > gridSize, `Ship did not move beyond grid: ${ship.x}`);
+  ship.update(1, waterTiles, gridSize, worldWidth, worldHeight);
+  assert.equal(ship.x, worldWidth);
+
+  // move north beyond 0
+  ship.x = 50;
+  ship.y = 5;
+  ship.speed = 100;
+  ship.angle = -Math.PI / 2; // north
+  ship.update(1, waterTiles, gridSize, worldWidth, worldHeight);
+  assert.equal(ship.y, 0);
+
+  // move south beyond height
+  ship.y = 95;
+  ship.speed = 100;
+  ship.angle = Math.PI / 2; // south
+  ship.update(1, waterTiles, gridSize, worldWidth, worldHeight);
+  assert.equal(ship.y, worldHeight);
 });


### PR DESCRIPTION
## Summary
- Add world width/height to `Ship.update` and clamp new positions within bounds
- Forward world dimensions from main loop and NPC ships
- Test that ships cannot move beyond world edges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9acbf3a80832fae8a9bd71ca6e05a