### PR TITLE
Add WASD controls to pirate ship movement

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -68,11 +68,15 @@ window.addEventListener('keydown', e => {
   if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', ' '].includes(e.key)) {
     e.preventDefault();
   }
-  keys[e.key] = true;
+  const map = { w: 'ArrowUp', a: 'ArrowLeft', s: 'ArrowDown', d: 'ArrowRight' };
+  if (map[e.key]) keys[map[e.key]] = true;
+  else keys[e.key] = true;
 });
 
 window.addEventListener('keyup', e => {
-  keys[e.key] = false;
+  const map = { w: 'ArrowUp', a: 'ArrowLeft', s: 'ArrowDown', d: 'ArrowRight' };
+  if (map[e.key]) keys[map[e.key]] = false;
+  else keys[e.key] = false;
 });
 
 const NATIONS = ['England', 'France', 'Spain', 'Netherlands'];

--- a/pirates/ui/commandKeys.js
+++ b/pirates/ui/commandKeys.js
@@ -3,9 +3,9 @@ export function initCommandKeys() {
   if (!div) return;
   div.innerHTML = `
     <strong>Command Keys:</strong>
-    <div data-cmd="move">&uarr; : Move forward</div>
-    <div data-cmd="slow">&darr; : Slow down</div>
-    <div data-cmd="rotate">&larr; / &rarr; : Rotate ship</div>
+    <div data-cmd="move">&uarr; / W : Move forward</div>
+    <div data-cmd="slow">&darr; / S : Slow down</div>
+    <div data-cmd="rotate">&larr; / &rarr; or A / D : Rotate ship</div>
     <div data-cmd="fire">Space: Fire cannon</div>
     <div data-cmd="pause">P: Pause/Unpause</div>
     <div data-cmd="minimap">M: Toggle minimap</div>


### PR DESCRIPTION
## Summary
- Map WASD keys to the same movement flags as arrow keys
- Show WASD alternatives in the command key overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9b4e8c734832f819cafc09e7ac387