### PR TITLE
Expand drawWorld bounds for edge tiles

### DIFF
--- a/pirates/world.js
+++ b/pirates/world.js
@@ -221,10 +221,18 @@ export function drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight,
   const rVals = corners.map(p => p.r);
   const cVals = corners.map(p => p.c);
 
+  // Determine visible tile bounds.
   let firstRow = Math.max(0, Math.floor(Math.min(...rVals)));
   let lastRow = Math.min(tiles.length - 1, Math.ceil(Math.max(...rVals)));
   let firstCol = Math.max(0, Math.floor(Math.min(...cVals)));
   let lastCol = Math.min(tiles[0].length - 1, Math.ceil(Math.max(...cVals)));
+
+  // Expand bounds by one tile in all directions to ensure edge tiles are drawn
+  // when the camera pans near map boundaries.
+  firstRow = Math.max(0, firstRow - 1);
+  firstCol = Math.max(0, firstCol - 1);
+  lastRow = Math.min(tiles.length - 1, lastRow + 1);
+  lastCol = Math.min(tiles[0].length - 1, lastCol + 1);
 
   for (let r = firstRow; r <= lastRow; r++) {
     for (let c = firstCol; c <= lastCol; c++) {

--- a/test/world.test.js
+++ b/test/world.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { tileAt, Terrain } from '../pirates/world.js';
+import { tileAt, Terrain, drawWorld } from '../pirates/world.js';
 import { Ship } from '../pirates/entities/ship.js';
 
 // Helper tiles: single water tile
@@ -59,4 +59,41 @@ test('ship cannot move past corner boundaries', () => {
   ship.update(1, waterTiles, gridSize, worldWidth, worldHeight);
   assert.equal(ship.x, 0);
   assert.equal(ship.y, 0);
+});
+
+test('drawWorld renders edge tile near map boundary', () => {
+  // bottom-right tile is land to test drawing at edge
+  const tiles = [
+    [Terrain.WATER, Terrain.WATER],
+    [Terrain.WATER, Terrain.LAND]
+  ];
+  const tileWidth = 64;
+  const tileImageHeight = 64;
+  const tileIsoHeight = 32;
+  const assets = {
+    tiles: {
+      land: { width: tileWidth, height: tileImageHeight },
+      water: { width: tileWidth, height: tileImageHeight }
+    }
+  };
+  const calls = [];
+  const ctx = {
+    canvas: { clientWidth: tileWidth, clientHeight: tileImageHeight },
+    drawImage: (...args) => calls.push(args)
+  };
+  // Pan close to the bottom-right corner
+  drawWorld(
+    ctx,
+    tiles,
+    tileWidth,
+    tileIsoHeight,
+    tileImageHeight,
+    assets,
+    tileWidth - 1,
+    tileImageHeight - 1
+  );
+  assert.ok(
+    calls.some(args => args[0] === assets.tiles.land),
+    'edge tile should be drawn'
+  );
 });


### PR DESCRIPTION
## Summary
- Expand `drawWorld` tile bounds by one on each side and clamp to grid limits so edge tiles render when panning
- Add test verifying that camera near map boundary still draws the edge tile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9ce1de770832fa12fc06bc055f3bc