### PR TITLE
Log distance to nearby village in console

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -419,9 +419,18 @@ function loop(timestamp) {
   if (showMinimap) {
     drawMinimap(minimapCtx, tiles, player, worldWidth, worldHeight);
   }
-
-  const nearbyCity = cities.find(c => Math.hypot(player.x - c.x, player.y - c.y) < 32);
+  const nearestCityInfo = cities.reduce(
+    (nearest, c) => {
+      const dist = Math.hypot(player.x - c.x, player.y - c.y);
+      return dist < nearest.dist ? { city: c, dist } : nearest;
+    },
+    { city: null, dist: Infinity }
+  );
+  const nearbyCity = nearestCityInfo.dist < 32 ? nearestCityInfo.city : null;
   if (nearbyCity) {
+    console.log(
+      `${nearbyCity.name} is ${nearestCityInfo.dist.toFixed(1)} units away`
+    );
     if (!player.inPort) {
       bus.emit('log', `Approaching ${nearbyCity.name}`);
       player.visitPort();


### PR DESCRIPTION
## Summary
- Compute nearest city distance each frame and log its proximity
- Keep existing port approach logic intact while reporting distance in console

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d4e1d444832f8a7c6dfae090a3d0