### PR TITLE
Add shared distance utilities and refactor usage

### DIFF
--- a/pirates/entities/npcShip.js
+++ b/pirates/entities/npcShip.js
@@ -1,6 +1,7 @@
 import { Ship } from './ship.js';
 import { bus } from '../bus.js';
 import { Projectile } from './projectile.js';
+import { cartesian } from '../utils/distance.js';
 
 // Tunable difficulty parameters for NPC behavior
 export const npcDifficulty = {
@@ -21,7 +22,7 @@ export class NpcShip extends Ship {
   }
 
   update(dt, tiles, gridSize, player, worldWidth, worldHeight) {
-    const dist = Math.hypot(player.x - this.x, player.y - this.y);
+    const dist = cartesian(player.x, player.y, this.x, this.y);
     const relation = bus.getRelation
       ? bus.getRelation(this.nation, player.nation)
       : 'peace';
@@ -82,7 +83,7 @@ export class NpcShip extends Ship {
       : 'peace';
     if (relation !== 'war') return;
 
-    const dist = Math.hypot(target.x - this.x, target.y - this.y);
+    const dist = cartesian(target.x, target.y, this.x, this.y);
     if (dist > this.fireRange) return;
 
     // predict target movement to lead shots

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -1,5 +1,6 @@
 import { assets, loadAssets } from './assets.js';
 import { generateWorld, drawWorld, Terrain, cartToIso } from './world.js';
+import { cartesian } from './utils/distance.js';
 import { Ship } from './entities/ship.js';
 import { NpcShip } from './entities/npcShip.js';
 import { City } from './entities/city.js';
@@ -380,7 +381,7 @@ function loop(timestamp) {
   // projectile collisions
   npcShips.forEach(n => {
     player.projectiles.forEach(p => {
-      if (!n.sunk && Math.hypot(p.x - n.x, p.y - n.y) < 20) {
+      if (!n.sunk && cartesian(p.x, p.y, n.x, n.y) < 20) {
         n.takeDamage(25);
         p.life = 0;
         bus.emit('log', `Hit ${n.nation} ship for 25 damage`);
@@ -391,7 +392,7 @@ function loop(timestamp) {
       }
     });
     n.projectiles.forEach(p => {
-      if (!player.sunk && Math.hypot(p.x - player.x, p.y - player.y) < 20) {
+      if (!player.sunk && cartesian(p.x, p.y, player.x, player.y) < 20) {
         player.takeDamage(25);
         p.life = 0;
         bus.emit('log', `Hit by ${n.nation} ship!`);
@@ -407,7 +408,7 @@ function loop(timestamp) {
   let nearEnemy = false;
   for (let i = 0; i < npcShips.length; i++) {
     const n = npcShips[i];
-    const dist = Math.hypot(player.x - n.x, player.y - n.y);
+    const dist = cartesian(player.x, player.y, n.x, n.y);
     if (dist < 30) nearEnemy = true;
     if (dist < 30 && (keys['b'] || keys['B'])) {
       startBoarding(player, n);
@@ -429,7 +430,7 @@ function loop(timestamp) {
   }
   const nearestCityInfo = cities.reduce(
     (nearest, c) => {
-      const dist = Math.hypot(player.x - c.x, player.y - c.y);
+      const dist = cartesian(player.x, player.y, c.x, c.y);
       return dist < nearest.dist ? { city: c, dist } : nearest;
     },
     { city: null, dist: Infinity }

--- a/pirates/utils/distance.js
+++ b/pirates/utils/distance.js
@@ -1,0 +1,19 @@
+import { isoToCart } from '../world.js';
+
+export function cartesian(x1, y1, x2, y2) {
+  return Math.hypot(x2 - x1, y2 - y1);
+}
+
+export function iso(
+  aIsoX,
+  aIsoY,
+  bIsoX,
+  bIsoY,
+  tileWidth,
+  tileIsoHeight,
+  tileImageHeight
+) {
+  const a = isoToCart(aIsoX, aIsoY, tileWidth, tileIsoHeight, tileImageHeight);
+  const b = isoToCart(bIsoX, bIsoY, tileWidth, tileIsoHeight, tileImageHeight);
+  return cartesian(a.x, a.y, b.x, b.y);
+}

--- a/pirates/world.js
+++ b/pirates/world.js
@@ -1,4 +1,5 @@
 import { assets } from './assets.js';
+import { iso } from './utils/distance.js';
 
 // Attempt to import simplex-noise locally for Node environments; fall back to CDN for browsers.
 let createNoise2D;
@@ -141,23 +142,6 @@ export function isoToCart(isoX, isoY, tileWidth, tileIsoHeight, tileImageHeight)
   return { x: cartX, y: cartY };
 }
 
-// Calculate the Euclidean distance between two isometric points.
-export function isoDistance(
-  aIsoX,
-  aIsoY,
-  bIsoX,
-  bIsoY,
-  tileWidth,
-  tileIsoHeight,
-  tileImageHeight
-) {
-  const a = isoToCart(aIsoX, aIsoY, tileWidth, tileIsoHeight, tileImageHeight);
-  const b = isoToCart(bIsoX, bIsoY, tileWidth, tileIsoHeight, tileImageHeight);
-  const dx = b.x - a.x;
-  const dy = b.y - a.y;
-  return Math.sqrt(dx * dx + dy * dy);
-}
-
 // Translate canvas/screen coordinates into fractional tile indices.
 export function screenToTile(
   cssX,
@@ -178,6 +162,8 @@ export function screenToTile(
     c: sy / tileIsoHeight + sx / tileWidth
   };
 }
+
+export { iso };
 
 // Backward compatibility: accept cartesian offsets and convert internally.
 export function screenToTileWithOffset(

--- a/test/distance.test.js
+++ b/test/distance.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cartesian, iso } from '../pirates/utils/distance.js';
+import { cartToIso } from '../pirates/world.js';
+
+const tileWidth = 64;
+const tileImageHeight = 64;
+const tileIsoHeight = 32;
+
+test('cartesian returns 0 for identical points', () => {
+  assert.equal(cartesian(1, 2, 1, 2), 0);
+});
+
+test('cartesian matches hypot for diagonal movement', () => {
+  const dist = cartesian(0, 0, 3, 4);
+  assert.equal(dist, 5);
+});
+
+test('iso returns 0 for the same isometric point', () => {
+  const { isoX, isoY } = cartToIso(10, 20, tileWidth, tileIsoHeight, tileImageHeight);
+  const dist = iso(
+    isoX,
+    isoY,
+    isoX,
+    isoY,
+    tileWidth,
+    tileIsoHeight,
+    tileImageHeight
+  );
+  assert.equal(dist, 0);
+});
+
+test('iso matches cartesian distance for diagonal movement', () => {
+  const a = { x: 0, y: 0 };
+  const b = { x: 64, y: 64 };
+  const isoA = cartToIso(a.x, a.y, tileWidth, tileIsoHeight, tileImageHeight);
+  const isoB = cartToIso(b.x, b.y, tileWidth, tileIsoHeight, tileImageHeight);
+  const expected = cartesian(a.x, a.y, b.x, b.y);
+  const dist = iso(
+    isoA.isoX,
+    isoA.isoY,
+    isoB.isoX,
+    isoB.isoY,
+    tileWidth,
+    tileIsoHeight,
+    tileImageHeight
+  );
+  assert.equal(dist, expected);
+});

--- a/test/world.test.js
+++ b/test/world.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { tileAt, Terrain, drawWorld, isoDistance, cartToIso } from '../pirates/world.js';
+import { tileAt, Terrain, drawWorld, cartToIso } from '../pirates/world.js';
 import { Ship } from '../pirates/entities/ship.js';
 
 // Helper tiles: single water tile
@@ -61,43 +61,6 @@ test('ship cannot move past corner boundaries', () => {
   assert.equal(ship.y, 0);
 });
 
-test('isoDistance returns 0 for the same isometric point', () => {
-  const tileWidth = 64;
-  const tileImageHeight = 64;
-  const tileIsoHeight = 32;
-  const { isoX, isoY } = cartToIso(10, 20, tileWidth, tileIsoHeight, tileImageHeight);
-  const dist = isoDistance(
-    isoX,
-    isoY,
-    isoX,
-    isoY,
-    tileWidth,
-    tileIsoHeight,
-    tileImageHeight
-  );
-  assert.equal(dist, 0);
-});
-
-test('isoDistance matches cartesian distance for diagonal movement', () => {
-  const tileWidth = 64;
-  const tileImageHeight = 64;
-  const tileIsoHeight = 32;
-  const a = { x: 0, y: 0 };
-  const b = { x: 64, y: 64 };
-  const isoA = cartToIso(a.x, a.y, tileWidth, tileIsoHeight, tileImageHeight);
-  const isoB = cartToIso(b.x, b.y, tileWidth, tileIsoHeight, tileImageHeight);
-  const expected = Math.hypot(b.x - a.x, b.y - a.y);
-  const dist = isoDistance(
-    isoA.isoX,
-    isoA.isoY,
-    isoB.isoX,
-    isoB.isoY,
-    tileWidth,
-    tileIsoHeight,
-    tileImageHeight
-  );
-  assert.equal(dist, expected);
-});
 
 test('drawWorld renders edge tile near map boundary', () => {
   // bottom-right tile is land to test drawing at edge


### PR DESCRIPTION
## Summary
- add `cartesian` and `iso` helpers in a new `utils/distance.js`
- rely on `cartesian` for projectile collisions, boarding and AI logic
- cover distance helpers with dedicated unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9dbdbff30832fb1ac9835dec966f4