### PR TITLE
Close menus before opening trade interface

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -451,6 +451,7 @@ function loop(timestamp) {
   if (nearbyCity) {
     const metadata = cityMetadata.get(nearbyCity);
     if (keys['t'] || keys['T']) {
+      closeTradeMenu();
       closeGovernorMenu();
       closeTavernMenu();
       closeUpgradeMenu();


### PR DESCRIPTION
## Summary
- Ensure trade menu closes any open menus before opening

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9de03f69c832f96825db4800458ff