### PR TITLE
Allow trading when ship is one tile from city

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -501,7 +501,9 @@ function loop(timestamp) {
     },
     { city: null, dist: Infinity }
   );
-  const nearbyCity = nearestCityInfo.dist < 32 ? nearestCityInfo.city : null;
+  const TRADE_RANGE = gridSize; // distance at which trade becomes available
+  const nearbyCity =
+    nearestCityInfo.dist <= TRADE_RANGE ? nearestCityInfo.city : null;
   if (nearbyCity) {
     console.log(
       `${nearbyCity.name} is ${nearestCityInfo.dist.toFixed(1)} units away`

--- a/test/trade.test.js
+++ b/test/trade.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cartesian } from '../pirates/utils/distance.js';
+
+// Regression test for trade proximity threshold
+// Ensures trading is possible when exactly one tile away from a city
+
+test('trade menu triggers at one-tile distance', () => {
+  const gridSize = 64; // size of one tile
+  const player = { x: 0, y: 0 };
+  const city = { x: gridSize, y: 0, name: 'Testville' };
+  const cities = [city];
+  const keys = { T: true };
+  let tradeOpened = false;
+
+  const nearestCityInfo = cities.reduce(
+    (nearest, c) => {
+      const dist = cartesian(player.x, player.y, c.x, c.y);
+      return dist < nearest.dist ? { city: c, dist } : nearest;
+    },
+    { city: null, dist: Infinity }
+  );
+
+  const TRADE_RANGE = gridSize;
+  const nearbyCity =
+    nearestCityInfo.dist <= TRADE_RANGE ? nearestCityInfo.city : null;
+
+  if (nearbyCity && (keys['t'] || keys['T'])) {
+    tradeOpened = true; // would call openTradeMenu in the main game
+  }
+
+  assert.equal(nearbyCity, city);
+  assert.equal(tradeOpened, true);
+});
+


### PR DESCRIPTION
## Summary
- tie trade proximity to `gridSize` and use inclusive range
- add regression test for opening trade at one-tile distance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba5ccd07bc832fb2445a369e685be3