### PR TITLE
Add island-aware village generation and minimap city markers

### DIFF
--- a/pirates/ui/minimap.js
+++ b/pirates/ui/minimap.js
@@ -4,7 +4,14 @@ export function initMinimap() {
   // nothing needed for now
 }
 
-export function drawMinimap(ctx, tiles, player, worldWidth, worldHeight) {
+export function drawMinimap(
+  ctx,
+  tiles,
+  player,
+  worldWidth,
+  worldHeight,
+  cities = []
+) {
   if (!ctx || !tiles) return;
   const width = ctx.canvas.width;
   const height = ctx.canvas.height;
@@ -23,10 +30,17 @@ export function drawMinimap(ctx, tiles, player, worldWidth, worldHeight) {
       }
     }
   }
+  // Draw city markers
+  ctx.fillStyle = '#ff0';
+  cities.forEach(city => {
+    const x = (city.x / worldWidth) * width;
+    const y = (city.y / worldHeight) * height;
+    ctx.fillRect(x - 1, y - 1, 2, 2);
+  });
   if (player) {
     ctx.fillStyle = '#f00';
-    const x = player.x / worldWidth * width;
-    const y = player.y / worldHeight * height;
+    const x = (player.x / worldWidth) * width;
+    const y = (player.y / worldHeight) * height;
     ctx.fillRect(x - 2, y - 2, 4, 4);
   }
 }

--- a/test/minimap.test.js
+++ b/test/minimap.test.js
@@ -38,3 +38,20 @@ test('minimap draws land tiles', () => {
   drawMinimap(ctx, tiles, null, 10, 10);
   assert.equal(calls.length, 2);
 });
+
+test('minimap draws city markers', () => {
+  const tiles = [[Terrain.LAND]];
+  const calls = [];
+  const ctx = {
+    canvas: { width: 10, height: 10 },
+    clearRect() {},
+    fillStyle: '',
+    fillRect(x, y, w, h) {
+      calls.push({ x, y, w, h, fillStyle: this.fillStyle });
+    }
+  };
+  const cities = [{ x: 5, y: 5 }];
+  drawMinimap(ctx, tiles, null, 10, 10, cities);
+  // Expect background + land + city marker
+  assert.equal(calls.length, 3);
+});

--- a/test/worldVillages.test.js
+++ b/test/worldVillages.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generateWorld } from '../pirates/world.js';
+
+test('generateWorld returns villages with island ids', () => {
+  const { villages } = generateWorld(160, 160, 16, { seed: 1, villagesPerIsland: 2 });
+  assert.ok(villages.length > 0, 'should create at least one village');
+  villages.forEach(v => {
+    assert.equal(typeof v.islandId, 'number');
+  });
+});


### PR DESCRIPTION
## Summary
- Generate islands and place multiple coastal villages per island, returning island metadata
- Instantiate cities from village metadata and display them on the minimap
- Test world village metadata and minimap city marker rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba62805dfc832f9ecd5c3b7cede1ff