### PR TITLE
Expand goods and dynamic market events

### DIFF
--- a/pirates/ui/trade.js
+++ b/pirates/ui/trade.js
@@ -1,7 +1,17 @@
 import { bus } from '../bus.js';
 import { updateHUD } from './hud.js';
 
-export const PRICES = { Sugar: 10, Rum: 12, Tobacco: 15, Cotton: 8 };
+// Base prices for all tradable goods.
+// Expanded to support additional commodities.
+export const PRICES = {
+  Sugar: 10,
+  Rum: 12,
+  Tobacco: 15,
+  Cotton: 8,
+  Spice: 20,
+  Tea: 9,
+  Coffee: 14
+};
 
 function listGoods(metadata) {
   const goods = new Set();


### PR DESCRIPTION
## Summary
- add Spice, Tea, and Coffee to tradable goods
- track per-city production and consumption and balance inventories
- adjust market prices using stock ratios, inter-city deficits, and seasonal events that trigger price-change notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba711a6014832fb7a81814b4eb3a56