### PR TITLE
feat: add npc trade routes

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -534,7 +534,7 @@ function loop(timestamp) {
   drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight, assets, offsetX, offsetY);
 
   npcShips.forEach(n => {
-    n.update(dt, tiles, gridSize, player, worldWidth, worldHeight);
+    n.update(dt, tiles, gridSize, player, worldWidth, worldHeight, cityMetadata);
     n.fireCannons(player);
   });
 

--- a/pirates/ui/trade.js
+++ b/pirates/ui/trade.js
@@ -20,14 +20,14 @@ function listGoods(metadata) {
   return Array.from(goods);
 }
 
-function basePriceFor(good, metadata) {
+export function basePriceFor(good, metadata) {
   let price = PRICES[good];
   if (metadata?.supplies?.includes(good)) price = Math.round(price * 0.8);
   if (metadata?.demands?.includes(good)) price = Math.round(price * 1.2);
   return price;
 }
 
-function priceFor(good, metadata, multiplier = 1) {
+export function priceFor(good, metadata, multiplier = 1) {
   metadata.prices = metadata.prices || {};
   if (metadata.prices[good] == null) {
     metadata.prices[good] = basePriceFor(good, metadata);


### PR DESCRIPTION
## Summary
- allow NpcShip to plan trade routes between cities and trade cargo affecting local prices
- export trade pricing helpers for reuse outside the UI
- pass city metadata into NpcShip updates for route planning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba74cbc0e8832faa5036fcd1c9ac59