### PR TITLE
Handle flag assets with fallbacks and dynamic updates

### DIFF
--- a/pirates/entities/city.js
+++ b/pirates/entities/city.js
@@ -1,4 +1,4 @@
-import { assets } from '../assets.js';
+import { assets, getFlag } from '../assets.js';
 import { cartToIso } from '../world.js';
 
 export class City {
@@ -20,7 +20,7 @@ export class City {
 
     const { isoX, isoY } = cartToIso(this.x, this.y, tileWidth, tileIsoHeight, tileImageHeight);
     const img = assets.tiles.village;
-    const flag = assets.flags?.[this.nation];
+    const flag = getFlag(this.nation);
     if (img) {
       ctx.save();
       ctx.translate(isoX - offX, isoY - offY);

--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -1,4 +1,4 @@
-import { assets } from '../assets.js';
+import { getFlag, getShipSprite } from '../assets.js';
 import { Terrain, cartToIso, tileAt } from '../world.js';
 import { Projectile } from './projectile.js';
 import { bus } from '../bus.js';
@@ -16,6 +16,7 @@ export class Ship {
     this.y = y;
     this.nation = nation;
     this.type = type;
+    this.updateAppearance();
     const stats = SHIP_TYPES[type] || SHIP_TYPES.Sloop;
     this.speed = 0;
     this.baseMaxSpeed = stats.speed;
@@ -167,6 +168,17 @@ export class Ship {
       }
     }
     this.updateCrewStats();
+    this.updateAppearance();
+  }
+
+  setNation(nation) {
+    this.nation = nation;
+    this.updateAppearance();
+  }
+
+  updateAppearance() {
+    this.img = getShipSprite(this.type, this.nation);
+    this.flag = getFlag(this.nation);
   }
 
   draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {
@@ -179,10 +191,8 @@ export class Ship {
     );
 
     if (!this.sunk) {
-      const img =
-        assets.ship?.[this.type]?.[this.nation] ||
-        assets.ship?.[this.type]?.England;
-      const flag = assets.flags?.[this.nation];
+      const img = this.img;
+      const flag = this.flag;
       const { isoX, isoY } = cartToIso(
         this.x,
         this.y,


### PR DESCRIPTION
## Summary
- Centralize flag and ship sprite lookup with placeholder generation for missing nations
- Refresh ship visuals when type or nation changes and use centralized flag lookup for cities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba7c3b65e0832f86a1b2f72af791d7