### PR TITLE
Add persistent ship upgrades with city-specific modifiers

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -33,6 +33,11 @@ export class Ship {
     this.sunk = false;
     this.projectiles = [];
     this.reputation = {};
+    this.upgrades = {
+      reinforcedHull: 0,
+      improvedSails: 0,
+      crewQuarters: 0
+    };
 
     // sail control
     this.sail = 1; // 0 = furled, 1 = full

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -421,6 +421,14 @@ function setup(options = {}) {
       });
       if (!Object.keys(shipyard).length) shipyard = null;
     }
+    const upgrades = {};
+    ['reinforcedHull', 'improvedSails', 'crewQuarters'].forEach(u => {
+      if (rand() < 0.7) {
+        let mult = 1;
+        if (rand() < 0.3) mult = 0.8;
+        upgrades[u] = mult;
+      }
+    });
     cityMetadata.set(city, {
       nation,
       supplies: cfg.supplies,
@@ -428,7 +436,8 @@ function setup(options = {}) {
       production: cfg.production,
       consumption: cfg.consumption,
       islandId: cfg.islandId,
-      shipyard
+      shipyard,
+      upgrades
     });
   });
 
@@ -478,11 +487,16 @@ function saveGame() {
       angle: player.angle,
       type: player.type,
       maxSpeed: player.maxSpeed,
+      baseMaxSpeed: player.baseMaxSpeed,
       cargoCapacity: player.cargoCapacity,
       gold: player.gold,
       crew: player.crew,
+      crewMax: player.crewMax,
       hull: player.hull,
       hullMax: player.hullMax,
+      baseFireRate: player.baseFireRate,
+      fireRate: player.fireRate,
+      upgrades: player.upgrades,
       cargo: player.cargo,
       reputation: player.reputation
     }
@@ -504,7 +518,13 @@ function loadGame() {
     Object.assign(player, data.player);
     player.cargo = data.player.cargo || {};
     player.reputation = data.player.reputation || {};
+    player.upgrades = data.player.upgrades || {
+      reinforcedHull: 0,
+      improvedSails: 0,
+      crewQuarters: 0
+    };
     player.fleet = [player];
+    player.updateCrewStats();
     fleetController = new FleetController(player);
     bus.emit('log', 'Game loaded');
   } catch (e) {
@@ -730,7 +750,7 @@ function loop(timestamp) {
       closeTavernMenu();
       closeFleetMenu();
       closeShipyardMenu();
-      openUpgradeMenu(player);
+      openUpgradeMenu(player, metadata);
       keys['u'] = keys['U'] = false;
     }
     if (keys['y'] || keys['Y']) {


### PR DESCRIPTION
## Summary
- Introduce reinforced hull, improved sails, and crew quarters upgrades, respecting city-specific availability and discounts.
- Populate city metadata with upgrade modifiers and expose them in the shipwright menu.
- Save and load player upgrade levels and related stats to persist enhancements across sessions.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba7d958f40832fa7a898ec0f97ef8c