### PR TITLE
Add NPC nation economy for shipyard-based spawning

### DIFF
--- a/pirates/npcEconomy.js
+++ b/pirates/npcEconomy.js
@@ -1,0 +1,66 @@
+import { NpcShip } from './entities/npcShip.js';
+
+export const nationEconomy = new Map();
+
+export function initEconomy(nations, initialGold = 1000) {
+  nationEconomy.clear();
+  nations.forEach(n => {
+    nationEconomy.set(n, { gold: initialGold });
+  });
+}
+
+export function earnIncome(amount = 100) {
+  nationEconomy.forEach(e => {
+    e.gold += amount;
+  });
+}
+
+export function restockShipyards(cityMetadata, amount = 1) {
+  cityMetadata.forEach(meta => {
+    if (meta.shipyard) {
+      Object.values(meta.shipyard).forEach(info => {
+        info.stock += amount;
+      });
+    }
+  });
+}
+
+export function spawnNpcFromEconomy(
+  nations,
+  cities,
+  cityMetadata,
+  npcShips,
+  targetCounts,
+  gridSize
+) {
+  nations.forEach(nation => {
+    const econ = nationEconomy.get(nation);
+    if (!econ) return;
+    let count = npcShips.filter(s => s.nation === nation).length;
+    while (count < targetCounts[nation]) {
+      const cityCandidates = cities.filter(c => {
+        const meta = cityMetadata.get(c);
+        if (!meta || meta.nation !== nation || !meta.shipyard) return false;
+        return Object.values(meta.shipyard).some(
+          info => info.stock > 0 && econ.gold >= info.price
+        );
+      });
+      if (!cityCandidates.length) break;
+      const city =
+        cityCandidates[Math.floor(Math.random() * cityCandidates.length)];
+      const meta = cityMetadata.get(city);
+      const availableTypes = Object.entries(meta.shipyard).filter(
+        ([, info]) => info.stock > 0 && econ.gold >= info.price
+      );
+      if (!availableTypes.length) break;
+      const [type, info] =
+        availableTypes[Math.floor(Math.random() * availableTypes.length)];
+      econ.gold -= info.price;
+      info.stock -= 1;
+      const x = city.x + gridSize;
+      const y = city.y;
+      npcShips.push(new NpcShip(x, y, nation, type));
+      count++;
+    }
+  });
+}

--- a/test/npcEconomy.test.js
+++ b/test/npcEconomy.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { City } from '../pirates/entities/city.js';
+import { cartesian } from '../pirates/utils/distance.js';
+import {
+  initEconomy,
+  nationEconomy,
+  spawnNpcFromEconomy
+} from '../pirates/npcEconomy.js';
+
+// Helper test ensuring nations purchase ships and spawn near cities
+
+test('NPC nations buy ships, paying gold and stock and spawn adjacent', () => {
+  const nations = ['England'];
+  const city = new City(0, 0, 'London', 'England');
+  const cities = [city];
+  const cityMetadata = new Map();
+  cityMetadata.set(city, {
+    nation: 'England',
+    shipyard: { Sloop: { price: 100, stock: 1 } }
+  });
+  const npcShips = [];
+  const targetCounts = { England: 1 };
+  const gridSize = 10;
+  initEconomy(nations, 150);
+
+  spawnNpcFromEconomy(
+    nations,
+    cities,
+    cityMetadata,
+    npcShips,
+    targetCounts,
+    gridSize
+  );
+
+  assert.equal(npcShips.length, 1);
+  const econ = nationEconomy.get('England');
+  assert.equal(econ.gold, 50);
+  assert.equal(cityMetadata.get(city).shipyard.Sloop.stock, 0);
+  const ship = npcShips[0];
+  const dist = cartesian(ship.x, ship.y, city.x, city.y);
+  assert.ok(dist <= gridSize);
+});


### PR DESCRIPTION
## Summary
- track gold for each NPC nation and restock shipyards over time
- spawn NPC ships by purchasing from city shipyards and deducting gold/stock
- test NPC purchases and ship spawning near the producing city

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba84f0850c832f873774e009f0915b