### PR TITLE
feat: allow NPCs to found new villages

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -14,8 +14,10 @@ import {
   initEconomy,
   earnIncome,
   restockShipyards,
-  spawnNpcFromEconomy
+  spawnNpcFromEconomy,
+  nationEconomy
 } from './npcEconomy.js';
+import { foundVillage } from './foundVillage.js';
 import { initHUD, updateHUD } from './ui/hud.js';
 import { initMinimap, drawMinimap } from './ui/minimap.js';
 import { initLog } from './ui/log.js';
@@ -286,6 +288,26 @@ function updateMarkets() {
     });
   }
   processPriceEvents();
+  attemptFoundVillages();
+}
+
+function attemptFoundVillages() {
+  if (!tiles) return;
+  NATIONS.forEach(nation => {
+    const econ = nationEconomy.get(nation);
+    if (!econ || econ.gold < 500) return;
+    const city = foundVillage(
+      tiles,
+      gridSize,
+      cities,
+      cityMetadata,
+      nation,
+      GOODS
+    );
+    if (city) {
+      econ.gold -= 500;
+    }
+  });
 }
 
 function setup(options = {}) {

--- a/test/foundVillage.test.js
+++ b/test/foundVillage.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Terrain } from '../pirates/world.js';
+import { drawMinimap } from '../pirates/ui/minimap.js';
+import { foundVillage, computeIslands } from '../pirates/foundVillage.js';
+import { City } from '../pirates/entities/city.js';
+import { NpcShip } from '../pirates/entities/npcShip.js';
+import { bus } from '../pirates/bus.js';
+
+const GOODS = ['Sugar'];
+
+function makeCtx() {
+  const calls = [];
+  return {
+    calls,
+    canvas: { width: 100, height: 100 },
+    fillStyle: '#000',
+    clearRect: () => {},
+    fillRect: (...args) => calls.push(args)
+  };
+}
+
+test('foundVillage creates village and renders on minimap', () => {
+  const W = Terrain.WATER, C = Terrain.COAST, L = Terrain.LAND;
+  const tiles = [
+    [W, C, W],
+    [C, L, C],
+    [W, C, W]
+  ];
+  const gridSize = 10;
+  const cities = [];
+  const cityMetadata = new Map();
+  const city = foundVillage(
+    tiles,
+    gridSize,
+    cities,
+    cityMetadata,
+    'England',
+    GOODS,
+    () => 0
+  );
+  assert.ok(city);
+  assert.equal(tiles[0][1], Terrain.VILLAGE);
+  assert.equal(cities.length, 1);
+  assert.equal(cityMetadata.get(city).nation, 'England');
+  const ctx = makeCtx();
+  const worldWidth = tiles[0].length * gridSize;
+  const worldHeight = tiles.length * gridSize;
+  drawMinimap(ctx, tiles, null, worldWidth, worldHeight, cities);
+  assert.ok(ctx.calls.some(c => c[2] === 2 && c[3] === 2));
+});
+
+test('new village joins trade routes and respects diplomacy', () => {
+  const W = Terrain.WATER, C = Terrain.COAST, L = Terrain.LAND, V = Terrain.VILLAGE;
+  const tiles = [
+    [W, V, W, W, C, W],
+    [W, L, W, W, L, W],
+    [W, C, W, W, C, W]
+  ];
+  const gridSize = 10;
+  const cities = [];
+  const cityMetadata = new Map();
+  const { islandMap } = computeIslands(tiles);
+  const islandAId = islandMap[0][1];
+  const cityA = new City(1 * gridSize + gridSize / 2, gridSize / 2, 'A', 'France');
+  cities.push(cityA);
+  cityMetadata.set(cityA, {
+    nation: 'France',
+    supplies: [],
+    demands: [],
+    production: {},
+    consumption: {},
+    islandId: islandAId
+  });
+  bus.nationRelations = {
+    England: { France: 'peace' },
+    France: { England: 'peace' }
+  };
+  bus.getRelation = (a, b) => bus.nationRelations[a]?.[b] || 'peace';
+  const cityB = foundVillage(
+    tiles,
+    gridSize,
+    cities,
+    cityMetadata,
+    'England',
+    GOODS,
+    () => 0
+  );
+  assert.ok(cityB);
+  assert.equal(cityMetadata.get(cityB).nation, 'England');
+  const npc = new NpcShip(0, 0, 'England');
+  const route = npc.chooseTradeRoute(cityMetadata);
+  assert.deepEqual(new Set([route.source, route.dest]), new Set([cityA, cityB]));
+  assert.equal(bus.getRelation('England', 'France'), 'peace');
+});


### PR DESCRIPTION
## Summary
- support NPC nations founding new coastal villages and populate economic metadata
- introduce daily check that spends gold to establish villages on eligible islands
- cover new village rendering, trade routes and diplomacy integration with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba860c32b0832fbdab2c99ac7e901c