### PR TITLE
Prevent adjacent villages and add coverage

### DIFF
--- a/pirates/foundVillage.js
+++ b/pirates/foundVillage.js
@@ -69,9 +69,25 @@ export function foundVillage(
   const { islands } = computeIslands(tiles);
   const candidates = islands
     .map(island => {
-      const available = island.coast.filter(
-        ({ r, c }) => tiles[r][c] === Terrain.COAST
-      );
+      const available = island.coast.filter(({ r, c }) => {
+        if (tiles[r][c] !== Terrain.COAST) return false;
+        for (let dr = -1; dr <= 1; dr++) {
+          for (let dc = -1; dc <= 1; dc++) {
+            if (dr === 0 && dc === 0) continue;
+            const nr = r + dr;
+            const nc = c + dc;
+            if (
+              nr >= 0 &&
+              nr < tiles.length &&
+              nc >= 0 &&
+              nc < tiles[0].length &&
+              tiles[nr][nc] === Terrain.VILLAGE
+            )
+              return false;
+          }
+        }
+        return true;
+      });
       if (!available.length) return null;
       const owners = new Set();
       cityMetadata.forEach(meta => {

--- a/pirates/world.js
+++ b/pirates/world.js
@@ -168,6 +168,24 @@ export function generateWorld(width, height, gridSize, options = {}) {
   } = options;
 
   const villages = [];
+  const hasVillageNearby = (r, c) => {
+    for (let dr = -1; dr <= 1; dr++) {
+      for (let dc = -1; dc <= 1; dc++) {
+        if (dr === 0 && dc === 0) continue;
+        const nr = r + dr,
+          nc = c + dc;
+        if (
+          nr >= 0 &&
+          nr < rows &&
+          nc >= 0 &&
+          nc < cols &&
+          tiles[nr][nc] === Terrain.VILLAGE
+        )
+          return true;
+      }
+    }
+    return false;
+  };
   for (const island of islands) {
     if (!island.coast.length) continue;
     let count;
@@ -176,11 +194,13 @@ export function generateWorld(width, height, gridSize, options = {}) {
     } else {
       count = Math.min(villagesPerIsland, island.coast.length);
     }
-    for (let i = 0; i < count && island.coast.length; i++) {
+    for (let i = 0; i < count && island.coast.length; ) {
       const idx = Math.floor(seededRandom(rngSeed++) * island.coast.length);
       const { r, c } = island.coast.splice(idx, 1)[0];
+      if (hasVillageNearby(r, c)) continue;
       tiles[r][c] = Terrain.VILLAGE;
       villages.push({ r, c, islandId: island.id });
+      i++;
     }
   }
 

--- a/test/foundVillage.test.js
+++ b/test/foundVillage.test.js
@@ -93,3 +93,27 @@ test('new village joins trade routes and respects diplomacy', () => {
   assert.deepEqual(new Set([route.source, route.dest]), new Set([cityA, cityB]));
   assert.equal(bus.getRelation('England', 'France'), 'peace');
 });
+
+test('cannot found village adjacent to another', () => {
+  const V = Terrain.VILLAGE, C = Terrain.COAST;
+  const tiles = [
+    [C, C, C],
+    [C, V, C],
+    [C, C, C]
+  ];
+  const gridSize = 10;
+  const cities = [];
+  const cityMetadata = new Map();
+  const city = foundVillage(
+    tiles,
+    gridSize,
+    cities,
+    cityMetadata,
+    'England',
+    GOODS,
+    () => 0
+  );
+  assert.equal(city, null);
+  const villageCount = tiles.flat().filter(t => t === Terrain.VILLAGE).length;
+  assert.equal(villageCount, 1);
+});

--- a/test/worldVillages.test.js
+++ b/test/worldVillages.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { generateWorld } from '../pirates/world.js';
+import { generateWorld, Terrain } from '../pirates/world.js';
 
 test('generateWorld returns villages with island ids', () => {
   const { villages } = generateWorld(160, 160, 16, { seed: 1, villagesPerIsland: 2 });
@@ -8,4 +8,30 @@ test('generateWorld returns villages with island ids', () => {
   villages.forEach(v => {
     assert.equal(typeof v.islandId, 'number');
   });
+});
+
+test('villages do not touch each other', () => {
+  const { tiles } = generateWorld(160, 160, 16, { seed: 2, villagesPerIsland: 2 });
+  const rows = tiles.length;
+  const cols = tiles[0].length;
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (tiles[r][c] !== Terrain.VILLAGE) continue;
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          if (dr === 0 && dc === 0) continue;
+          const nr = r + dr;
+          const nc = c + dc;
+          if (
+            nr >= 0 &&
+            nr < rows &&
+            nc >= 0 &&
+            nc < cols
+          ) {
+            assert.notEqual(tiles[nr][nc], Terrain.VILLAGE);
+          }
+        }
+      }
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- enforce village spacing during world generation
- skip founding villages adjacent to existing ones
- test that villages never touch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba88b32544832f95159989ed87b4ae