### PR TITLE
Add European traders that supply cities

### DIFF
--- a/pirates/entities/npcShip.js
+++ b/pirates/entities/npcShip.js
@@ -20,6 +20,7 @@ export class NpcShip extends Ship {
     this.targetCity = null;
     this.loaded = false;
     this.prevState = null;
+    this.home = null;
 
     // firing behavior parameters
     this.cannonRange = difficulty.range;
@@ -169,6 +170,34 @@ export class NpcShip extends Ship {
           }
         } else {
           this.inPort = false;
+        }
+        break;
+
+      case 'europe-trade':
+        if (this.loaded && this.targetCity) {
+          const t = this.targetCity;
+          this.speed = 2;
+          this.angle = Math.atan2(t.y - this.y, t.x - this.x);
+          const d = cartesian(t.x, t.y, this.x, this.y);
+          if (d < gridSize) {
+            const metadata = cityMetadata.get(t);
+            if (metadata) {
+              metadata.inventory = metadata.inventory || {};
+              for (const good of Object.keys(this.cargo)) {
+                metadata.inventory[good] =
+                  (metadata.inventory[good] || 0) + this.cargo[good];
+              }
+            }
+            this.cargo = {};
+            this.loaded = false;
+          }
+        } else if (this.home) {
+          this.speed = 2;
+          this.angle = Math.atan2(this.home.y - this.y, this.home.x - this.x);
+          const d = cartesian(this.home.x, this.home.y, this.x, this.y);
+          if (d < gridSize) {
+            this.sunk = true;
+          }
         }
         break;
 

--- a/pirates/europeTraders.js
+++ b/pirates/europeTraders.js
@@ -1,0 +1,53 @@
+import { NpcShip } from './entities/npcShip.js';
+import { cartesian } from './utils/distance.js';
+
+// Interval (ms) between spawns of European traders
+export const EUROPE_TRADER_INTERVAL = 60000;
+
+// Possible goods carried by European traders by nation
+const EUROPEAN_CARGO_TABLE = {
+  England: { Tools: 5, Cloth: 5 },
+  France: { Wine: 5, Cloth: 5 },
+  Spain: { Tools: 5, Guns: 5 },
+  Netherlands: { Cloth: 5, Tools: 5 }
+};
+
+const EUROPEAN_NATIONS = Object.keys(EUROPEAN_CARGO_TABLE);
+
+// Compute a random spawn point along the world edge
+function randomEdgePoint(width, height) {
+  const edge = Math.floor(Math.random() * 4);
+  switch (edge) {
+    case 0:
+      return { x: 0, y: Math.random() * height };
+    case 1:
+      return { x: width, y: Math.random() * height };
+    case 2:
+      return { x: Math.random() * width, y: 0 };
+    default:
+      return { x: Math.random() * width, y: height };
+  }
+}
+
+export function spawnEuropeanTrader(worldWidth, worldHeight, cities) {
+  if (!cities?.length) return null;
+  const spawn = randomEdgePoint(worldWidth, worldHeight);
+  const nation =
+    EUROPEAN_NATIONS[Math.floor(Math.random() * EUROPEAN_NATIONS.length)];
+  const ship = new NpcShip(spawn.x, spawn.y, nation);
+  ship.state = 'europe-trade';
+  ship.home = { ...spawn };
+  ship.cargo = { ...(EUROPEAN_CARGO_TABLE[nation] || {}) };
+  ship.loaded = true;
+
+  // Find nearest city to deliver goods
+  const nearest = cities.reduce(
+    (closest, c) => {
+      const d = cartesian(spawn.x, spawn.y, c.x, c.y);
+      return d < closest.dist ? { city: c, dist: d } : closest;
+    },
+    { city: null, dist: Infinity }
+  );
+  ship.targetCity = nearest.city;
+  return ship;
+}

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -17,6 +17,7 @@ import {
   spawnNpcFromEconomy,
   nationEconomy
 } from './npcEconomy.js';
+import { spawnEuropeanTrader, EUROPE_TRADER_INTERVAL } from './europeTraders.js';
 import { foundVillage } from './foundVillage.js';
 import { initHUD, updateHUD } from './ui/hud.js';
 import { initMinimap, drawMinimap } from './ui/minimap.js';
@@ -76,7 +77,7 @@ bus.on('switch-flagship', ({ ship }) => {
 // Dynamic game state collections
 let tiles, player, cities, cityMetadata, npcShips, priceEvents = [], seasonalEvents = [];
 let fleetController;
-let npcSpawnIntervalId;
+let npcSpawnIntervalId, europeTraderIntervalId;
 const keys = {};
 
 bus.on('price-change', ({ city, good, delta }) => {
@@ -479,6 +480,17 @@ function setup(options = {}) {
   spawnNpc();
   if (npcSpawnIntervalId) clearInterval(npcSpawnIntervalId);
   npcSpawnIntervalId = setInterval(spawnNpc, npcSpawnFrequency);
+
+  const spawnEuropean = () => {
+    const trader = spawnEuropeanTrader(worldWidth, worldHeight, cities);
+    if (trader) npcShips.push(trader);
+  };
+  spawnEuropean();
+  if (europeTraderIntervalId) clearInterval(europeTraderIntervalId);
+  europeTraderIntervalId = setInterval(
+    spawnEuropean,
+    EUROPE_TRADER_INTERVAL
+  );
 
   questManager.addQuest(new Quest('capture', 'Capture an enemy ship', 'England', 10));
 

--- a/test/europeTraders.test.js
+++ b/test/europeTraders.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { City } from '../pirates/entities/city.js';
+import { spawnEuropeanTrader } from '../pirates/europeTraders.js';
+
+// Ensure European traders spawn with proper nation and deliver goods
+
+test('European traders reach nearest city', () => {
+  const worldWidth = 200;
+  const worldHeight = 200;
+  const gridSize = 10;
+  const city = new City(100, 100, 'Testopolis', 'England');
+  const cities = [city];
+  const cityMetadata = new Map([[city, { inventory: {} }]]);
+  const npcShips = [];
+
+  const trader = spawnEuropeanTrader(worldWidth, worldHeight, cities);
+  npcShips.push(trader);
+
+  const europeanNations = ['England', 'France', 'Spain', 'Netherlands'];
+  assert.ok(europeanNations.includes(trader.nation));
+
+  const player = { x: 1000, y: 1000, nation: 'Pirate' };
+  let steps = 0;
+  while (trader.loaded && steps < 1000) {
+    trader.update(
+      1,
+      null,
+      gridSize,
+      player,
+      worldWidth,
+      worldHeight,
+      cityMetadata
+    );
+    steps++;
+  }
+
+  assert.equal(trader.loaded, false);
+  const meta = cityMetadata.get(city);
+  const total = Object.values(meta.inventory).reduce((a, b) => a + b, 0);
+  assert.ok(total > 0);
+});


### PR DESCRIPTION
## Summary
- add `spawnEuropeanTrader` to generate traders carrying European goods from world edges
- schedule European traders in main loop
- extend `NpcShip` with `europe-trade` state to deliver cargo then sail home
- test ensures traders spawn with European nation and reach cities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba89dbb2ec832f99543a32dc64ea32