### PR TITLE
Add road terrain and production bonuses for connected cities

### DIFF
--- a/pirates/entities/city.js
+++ b/pirates/entities/city.js
@@ -7,6 +7,7 @@ export class City {
     this.y = y;
     this.name = name;
     this.nation = nation;
+    this.roads = new Set();
   }
 
   draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {

--- a/pirates/foundVillage.js
+++ b/pirates/foundVillage.js
@@ -8,7 +8,8 @@ function isIslandLand(t) {
     t === Terrain.DESERT ||
     t === Terrain.FOREST ||
     t === Terrain.COAST ||
-    t === Terrain.VILLAGE
+    t === Terrain.VILLAGE ||
+    t === Terrain.ROAD
   );
 }
 
@@ -126,7 +127,8 @@ export function foundVillage(
     consumption,
     islandId: choice.island.id,
     shipyard: null,
-    upgrades: {}
+    upgrades: {},
+    roads: new Set()
   });
   return city;
 }

--- a/pirates/npcEconomy.js
+++ b/pirates/npcEconomy.js
@@ -25,6 +25,18 @@ export function restockShipyards(cityMetadata, amount = 1) {
   });
 }
 
+// Calculate effective production for a city, applying a bonus for each road
+// connection. Each connection increases output by 50%.
+export function calculateProduction(metadata) {
+  const connections = metadata?.roads?.size || 0;
+  const multiplier = 1 + connections * 0.5;
+  const result = {};
+  Object.entries(metadata?.production || {}).forEach(([good, amt]) => {
+    result[good] = Math.round(amt * multiplier);
+  });
+  return result;
+}
+
 export function spawnNpcFromEconomy(
   nations,
   cities,

--- a/pirates/ui/buildRoad.js
+++ b/pirates/ui/buildRoad.js
@@ -1,0 +1,46 @@
+import { Terrain } from '../world.js';
+import { bus } from '../bus.js';
+
+// Build a simple orthogonal road between two cities.
+// Updates the tiles grid to mark road tiles and records the connection
+// in city metadata adjacency sets.
+export function buildRoad(tiles, cityA, cityB, cityMetadata, gridSize) {
+  if (!tiles || !cityA || !cityB || !cityMetadata) return false;
+  const r1 = Math.floor(cityA.y / gridSize);
+  const c1 = Math.floor(cityA.x / gridSize);
+  const r2 = Math.floor(cityB.y / gridSize);
+  const c2 = Math.floor(cityB.x / gridSize);
+
+  let r = r1;
+  let c = c1;
+  const dr = Math.sign(r2 - r1);
+  const dc = Math.sign(c2 - c1);
+
+  while (r !== r2) {
+    r += dr;
+    if (tiles[r] && tiles[r][c] !== Terrain.VILLAGE) {
+      tiles[r][c] = Terrain.ROAD;
+    }
+  }
+  while (c !== c2) {
+    c += dc;
+    if (tiles[r] && tiles[r][c] !== Terrain.VILLAGE) {
+      tiles[r][c] = Terrain.ROAD;
+    }
+  }
+
+  const metaA = cityMetadata.get(cityA);
+  const metaB = cityMetadata.get(cityB);
+  if (metaA) {
+    metaA.roads = metaA.roads || new Set();
+    metaA.roads.add(cityB);
+  }
+  if (metaB) {
+    metaB.roads = metaB.roads || new Set();
+    metaB.roads.add(cityA);
+  }
+  cityA.roads?.add(cityB);
+  cityB.roads?.add(cityA);
+  bus.emit('log', `Built road between ${cityA.name} and ${cityB.name}`);
+  return true;
+}

--- a/pirates/world.js
+++ b/pirates/world.js
@@ -18,7 +18,8 @@ export const Terrain = {
   RIVER: 5,
   REEF: 6,
   DESERT: 7,
-  FOREST: 8
+  FOREST: 8,
+  ROAD: 9
 };
 
 export function generateWorld(width, height, gridSize, options = {}) {
@@ -89,7 +90,8 @@ export function generateWorld(width, height, gridSize, options = {}) {
     t === Terrain.LAND ||
     t === Terrain.HILL ||
     t === Terrain.DESERT ||
-    t === Terrain.FOREST;
+    t === Terrain.FOREST ||
+    t === Terrain.ROAD;
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
       if (!isLand(tiles[r][c])) continue;
@@ -123,7 +125,8 @@ export function generateWorld(width, height, gridSize, options = {}) {
     t === Terrain.HILL ||
     t === Terrain.DESERT ||
     t === Terrain.FOREST ||
-    t === Terrain.COAST;
+    t === Terrain.COAST ||
+    t === Terrain.ROAD;
 
   let islandId = 0;
   for (let r = 0; r < rows; r++) {
@@ -345,6 +348,7 @@ export function drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight,
       if (t === Terrain.WATER || t === Terrain.RIVER) img = assets.tiles?.water;
       else if (t === Terrain.HILL) img = assets.tiles?.hill;
       else if (t === Terrain.VILLAGE) img = assets.tiles?.village;
+      else if (t === Terrain.ROAD) img = assets.tiles?.road || assets.tiles?.land;
       else if (t === Terrain.COAST || t === Terrain.REEF) img = assets.tiles?.coast || assets.tiles?.land;
       else img = assets.tiles?.land;
       if (!img) continue;

--- a/test/roadProduction.test.js
+++ b/test/roadProduction.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Terrain } from '../pirates/world.js';
+import { City } from '../pirates/entities/city.js';
+import { buildRoad } from '../pirates/ui/buildRoad.js';
+import { calculateProduction } from '../pirates/npcEconomy.js';
+
+const gridSize = 10;
+
+function createCity(r, c, name) {
+  const x = c * gridSize + gridSize / 2;
+  const y = r * gridSize + gridSize / 2;
+  return new City(x, y, name, 'Test');
+}
+
+test('building a road increases production', () => {
+  const tiles = [
+    [Terrain.LAND, Terrain.LAND, Terrain.LAND],
+    [Terrain.LAND, Terrain.VILLAGE, Terrain.LAND],
+    [Terrain.LAND, Terrain.LAND, Terrain.VILLAGE]
+  ];
+
+  const cityA = createCity(1, 1, 'A');
+  const cityB = createCity(2, 2, 'B');
+
+  const cityMetadata = new Map();
+  cityMetadata.set(cityA, { production: { Sugar: 1 }, roads: new Set() });
+  cityMetadata.set(cityB, { production: { Sugar: 1 }, roads: new Set() });
+
+  const before = calculateProduction(cityMetadata.get(cityA)).Sugar;
+  assert.equal(before, 1);
+
+  buildRoad(tiles, cityA, cityB, cityMetadata, gridSize);
+  assert.equal(tiles[2][1], Terrain.ROAD);
+  assert.ok(cityMetadata.get(cityA).roads.has(cityB));
+
+  const after = calculateProduction(cityMetadata.get(cityA)).Sugar;
+  assert.ok(after > before);
+});


### PR DESCRIPTION
## Summary
- introduce ROAD terrain type with rendering support
- track road connections in city metadata and implement a road building helper
- apply road-network bonus to city production calculations with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba8aba48a0832fafd4a0bfa8595b8d