### PR TITLE
Add native settlements with trade and relations

### DIFF
--- a/pirates/entities/nativeSettlement.js
+++ b/pirates/entities/nativeSettlement.js
@@ -1,0 +1,39 @@
+import { assets } from '../assets.js';
+import { cartToIso } from '../world.js';
+
+export class NativeSettlement {
+  constructor(x, y, tribe) {
+    this.x = x;
+    this.y = y;
+    this.name = tribe;
+    this.tribe = tribe;
+    this.relation = 0;
+  }
+
+  draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {
+    const { isoX: offX, isoY: offY } = cartToIso(
+      offsetX,
+      offsetY,
+      tileWidth,
+      tileIsoHeight,
+      tileImageHeight
+    );
+    const { isoX, isoY } = cartToIso(
+      this.x,
+      this.y,
+      tileWidth,
+      tileIsoHeight,
+      tileImageHeight
+    );
+    const img = assets.tiles.native || assets.tiles.village;
+    if (img) {
+      ctx.save();
+      ctx.translate(isoX - offX, isoY - offY);
+      ctx.drawImage(img, -img.width / 2, -img.height / 2);
+      ctx.restore();
+    } else {
+      ctx.fillStyle = 'brown';
+      ctx.fillRect(isoX - 8 - offX, isoY - 8 - offY, 16, 16);
+    }
+  }
+}

--- a/pirates/foundVillage.js
+++ b/pirates/foundVillage.js
@@ -9,7 +9,8 @@ function isIslandLand(t) {
     t === Terrain.FOREST ||
     t === Terrain.COAST ||
     t === Terrain.VILLAGE ||
-    t === Terrain.ROAD
+    t === Terrain.ROAD ||
+    t === Terrain.NATIVE
   );
 }
 

--- a/pirates/npcEconomy.js
+++ b/pirates/npcEconomy.js
@@ -76,3 +76,8 @@ export function spawnNpcFromEconomy(
     }
   });
 }
+
+export function adjustNativeRelation(metadata, delta) {
+  if (typeof metadata.relation !== 'number') metadata.relation = 0;
+  metadata.relation += delta;
+}

--- a/pirates/ui/trade.js
+++ b/pirates/ui/trade.js
@@ -1,4 +1,5 @@
 import { bus } from '../bus.js';
+import { adjustNativeRelation } from '../npcEconomy.js';
 import { updateHUD } from './hud.js';
 
 // Base prices for all tradable goods.
@@ -48,8 +49,8 @@ export function openTradeMenu(player, city, metadata, priceMultiplier = 1) {
   const menu = document.getElementById('tradeMenu');
   if (!menu || !player) return;
 
-  if (!metadata?.nation) {
-    bus.emit('log', `Cannot open trade menu for ${city?.name || 'unknown city'}: nation unknown`);
+  if (!metadata?.nation && !metadata?.tribe) {
+    bus.emit('log', `Cannot open trade menu for ${city?.name || 'unknown location'}: faction unknown`);
     return;
   }
 
@@ -118,6 +119,7 @@ export function openTradeMenu(player, city, metadata, priceMultiplier = 1) {
       metadata.prices[good] = Math.round(oldPrice * 1.1);
       bus.emit('log', `Bought 1 ${good} for ${buyPrice}g`);
       bus.emit('price-change', { city, good, delta: metadata.prices[good] - oldPrice });
+      if (metadata.tribe) adjustNativeRelation(metadata, -1);
       updateHUD(player);
       openTradeMenu(player, city, metadata, priceMultiplier);
     };
@@ -142,6 +144,7 @@ export function openTradeMenu(player, city, metadata, priceMultiplier = 1) {
       metadata.prices[good] = Math.max(1, Math.round(oldPrice * 0.9));
       bus.emit('log', `Sold 1 ${good} for ${sellPrice}g`);
       bus.emit('price-change', { city, good, delta: metadata.prices[good] - oldPrice });
+      if (metadata.tribe) adjustNativeRelation(metadata, 1);
       updateHUD(player);
       openTradeMenu(player, city, metadata, priceMultiplier);
     };

--- a/test/nativeSettlements.test.js
+++ b/test/nativeSettlements.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generateWorld, Terrain } from '../pirates/world.js';
+import { adjustNativeRelation } from '../pirates/npcEconomy.js';
+
+test('generateWorld returns native settlements', () => {
+  const { tiles, natives } = generateWorld(160, 160, 16, { seed: 1, nativeDensity: 0.5 });
+  assert.ok(natives.length > 0, 'should create at least one native settlement');
+  natives.forEach(n => {
+    assert.equal(tiles[n.r][n.c], Terrain.NATIVE);
+  });
+});
+
+test('adjustNativeRelation updates relation value', () => {
+  const meta = { relation: 0 };
+  adjustNativeRelation(meta, 2);
+  assert.equal(meta.relation, 2);
+});


### PR DESCRIPTION
## Summary
- introduce Terrain.NATIVE and generate native settlements near forests and rivers
- add NativeSettlement entity and instantiate tribes with relations and limited goods
- enable trading with native settlements and adjust relations based on player actions
- reuse existing village tile for natives by removing native settlement image asset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8e6ae66c832f85f000865ed00e02