### PR TITLE
Add mission terrain and starting location

### DIFF
--- a/pirates/assets.js
+++ b/pirates/assets.js
@@ -21,6 +21,9 @@ export async function loadAssets(tileSize){
     const response = await fetch('/pirates/assets.json');
     const data = await response.json();
     await loadNested(data, assets);
+    if (!assets.tiles.mission) {
+      assets.tiles.mission = assets.tiles.village;
+    }
     ensureFlags();
     const sampleTile = assets.tiles && Object.values(assets.tiles)[0];
     const tileWidth = sampleTile?.tileWidth || sampleTile?.width || gridSize;

--- a/pirates/assets.json
+++ b/pirates/assets.json
@@ -3,7 +3,8 @@
     "water": "assets/seaTB128.png",
     "land": "assets/grassTB128.png",
     "village": "assets/villageTB128.png",
-    "hill": "assets/hillTB128.png"
+    "hill": "assets/hillTB128.png",
+    "mission": "assets/villageTB128.png"
   },
   "ship": {
     "Sloop": {

--- a/pirates/entities/mission.js
+++ b/pirates/entities/mission.js
@@ -1,0 +1,39 @@
+import { assets } from '../assets.js';
+import { cartToIso } from '../world.js';
+
+export class Mission {
+  constructor(x, y, name, nation = 'Mission') {
+    this.x = x;
+    this.y = y;
+    this.name = name;
+    this.nation = nation;
+    this.relation = 0;
+  }
+
+  draw(ctx, offsetX = 0, offsetY = 0, tileWidth, tileIsoHeight, tileImageHeight) {
+    const { isoX: offX, isoY: offY } = cartToIso(
+      offsetX,
+      offsetY,
+      tileWidth,
+      tileIsoHeight,
+      tileImageHeight
+    );
+    const { isoX, isoY } = cartToIso(
+      this.x,
+      this.y,
+      tileWidth,
+      tileIsoHeight,
+      tileImageHeight
+    );
+    const img = assets.tiles.mission || assets.tiles.village;
+    if (img) {
+      ctx.save();
+      ctx.translate(isoX - offX, isoY - offY);
+      ctx.drawImage(img, -img.width / 2, -img.height / 2);
+      ctx.restore();
+    } else {
+      ctx.fillStyle = 'white';
+      ctx.fillRect(isoX - 8 - offX, isoY - 8 - offY, 16, 16);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add mission tile asset and loader fallback
- Support `Terrain.MISSION` with world generation and rendering
- Create `Mission` entity and spawn player at mission location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baa039b414832f8232c918fd5f7fc2