### PR TITLE
feat: add research system

### DIFF
--- a/pirates/foundVillage.js
+++ b/pirates/foundVillage.js
@@ -1,5 +1,6 @@
 import { Terrain } from './world.js';
 import { City } from './entities/city.js';
+import { bus } from './bus.js';
 
 function isIslandLand(t) {
   return (
@@ -131,5 +132,6 @@ export function foundVillage(
     upgrades: {},
     roads: new Set()
   });
+  bus.emit('village-founded', { city, nation });
   return city;
 }

--- a/pirates/index.html
+++ b/pirates/index.html
@@ -98,7 +98,8 @@
     #upgradeMenu,
     #tavernMenu,
     #fleetMenu,
-    #shipyardMenu {
+    #shipyardMenu,
+    #researchMenu {
       position: absolute;
       top: 50%;
       left: 50%;
@@ -157,6 +158,7 @@
   <div id="shipyardMenu"></div>
   <div id="tavernMenu"></div>
   <div id="fleetMenu"></div>
+  <div id="researchMenu"></div>
   <div id="cardContainer" class="isometric-cards"></div>
 
     <script type="module" src="main.js"></script>

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -37,6 +37,8 @@ import { initCommandKeys, updateCommandKeys } from './ui/commandKeys.js';
 import { openFleetMenu, closeFleetMenu } from './ui/fleet.js';
 import { openShipyardMenu, closeShipyardMenu } from './ui/shipyard.js';
 import { FleetController } from './fleet.js';
+import { openResearchMenu, closeResearchMenu } from './ui/research.js';
+import { getResearchState, setResearchState } from './research.js';
 
 let worldWidth, worldHeight, gridSize, tileWidth, tileIsoHeight, tileImageHeight;
 const CSS_WIDTH = 800, CSS_HEIGHT = 600;
@@ -320,6 +322,7 @@ function setup(options = {}) {
     npcSpawnFrequency = 30000
   } = options;
   currentSeed = seed;
+  setResearchState();
   const result = generateWorld(worldWidth, worldHeight, gridSize, options);
   tiles = result.tiles;
   worldWidth = result.cols * gridSize;
@@ -566,7 +569,8 @@ function saveGame() {
       upgrades: player.upgrades,
       cargo: player.cargo,
       reputation: player.reputation
-    }
+    },
+    research: getResearchState()
   };
   try {
     localStorage.setItem('pirates-save', JSON.stringify(data));
@@ -593,6 +597,7 @@ function loadGame() {
     player.fleet = [player];
     player.updateCrewStats();
     fleetController = new FleetController(player);
+    setResearchState(data.research);
     bus.emit('log', 'Game loaded');
   } catch (e) {
     console.error('Load failed', e);
@@ -627,8 +632,19 @@ function loop(timestamp) {
     closeGovernorMenu();
     closeTavernMenu();
     closeUpgradeMenu();
+    closeResearchMenu();
     openFleetMenu(player);
     keys['f'] = keys['F'] = false;
+  }
+  if (keys['i'] || keys['I']) {
+    closeTradeMenu();
+    closeGovernorMenu();
+    closeTavernMenu();
+    closeUpgradeMenu();
+    closeFleetMenu();
+    closeShipyardMenu();
+    openResearchMenu();
+    keys['i'] = keys['I'] = false;
   }
 
   if (paused) {
@@ -779,6 +795,7 @@ function loop(timestamp) {
       closeUpgradeMenu();
       closeFleetMenu();
       closeShipyardMenu();
+      closeResearchMenu();
       if (metadata?.tribe) {
         const multiplier = 1 + Math.max(0, -metadata.relation) * 0.1;
         openTradeMenu(player, nearbyCity, metadata, multiplier);
@@ -806,6 +823,7 @@ function loop(timestamp) {
       closeUpgradeMenu();
       closeFleetMenu();
       closeShipyardMenu();
+      closeResearchMenu();
       openGovernorMenu(player, nearbyCity, metadata);
       keys['g'] = keys['G'] = false;
     }
@@ -815,6 +833,7 @@ function loop(timestamp) {
       closeUpgradeMenu();
       closeFleetMenu();
       closeShipyardMenu();
+      closeResearchMenu();
       openTavernMenu(player, nearbyCity);
       keys['v'] = keys['V'] = false;
     }
@@ -824,6 +843,7 @@ function loop(timestamp) {
       closeTavernMenu();
       closeFleetMenu();
       closeShipyardMenu();
+      closeResearchMenu();
       openUpgradeMenu(player, metadata);
       keys['u'] = keys['U'] = false;
     }
@@ -833,6 +853,7 @@ function loop(timestamp) {
       closeTavernMenu();
       closeUpgradeMenu();
       closeFleetMenu();
+      closeResearchMenu();
       if (metadata?.shipyard) {
         openShipyardMenu(player, nearbyCity, metadata);
       } else {
@@ -847,6 +868,7 @@ function loop(timestamp) {
     closeUpgradeMenu();
     closeFleetMenu();
     closeShipyardMenu();
+    closeResearchMenu();
   }
   requestAnimationFrame(loop);
 }

--- a/pirates/research.js
+++ b/pirates/research.js
@@ -1,0 +1,90 @@
+import { bus } from './bus.js';
+
+export class InnovationNode {
+  constructor(id, cost, prerequisites = [], effects = []) {
+    this.id = id;
+    this.cost = cost;
+    this.prerequisites = prerequisites;
+    this.effects = effects;
+  }
+}
+
+// Define a small example research tree. Games can extend this at runtime.
+const nodes = new Map();
+nodes.set('improvedSails', new InnovationNode('improvedSails', 20, [], [{ type: 'speed', value: 1 }]));
+nodes.set(
+  'reinforcedHull',
+  new InnovationNode('reinforcedHull', 30, ['improvedSails'], [{ type: 'hull', value: 10 }])
+);
+
+export function getResearchNodes() {
+  return Array.from(nodes.values());
+}
+
+export let researchPoints = 0;
+export let activeProject = null; // { id, progress }
+export const completedTech = new Set();
+
+export function isUnlocked(id) {
+  return completedTech.has(id);
+}
+
+export function startResearch(id) {
+  const node = nodes.get(id);
+  if (!node) return false;
+  if (completedTech.has(id)) return false;
+  if (!node.prerequisites.every(p => completedTech.has(p))) return false;
+  if (activeProject && activeProject.id !== id) return false;
+  if (!activeProject) activeProject = { id, progress: 0 };
+  applyResearch();
+  bus.emit('research-started', { id });
+  return true;
+}
+
+export function addResearchPoints(amount) {
+  researchPoints += amount;
+  applyResearch();
+  bus.emit('research-points', { points: researchPoints });
+}
+
+function applyResearch() {
+  if (!activeProject) return;
+  const node = nodes.get(activeProject.id);
+  if (!node) return;
+  const needed = node.cost - activeProject.progress;
+  const used = Math.min(needed, researchPoints);
+  activeProject.progress += used;
+  researchPoints -= used;
+  if (activeProject.progress >= node.cost) {
+    completedTech.add(node.id);
+    const finished = activeProject.id;
+    activeProject = null;
+    bus.emit('research-completed', { id: finished });
+  }
+  bus.emit('research-updated');
+}
+
+export function getResearchState() {
+  return {
+    points: researchPoints,
+    activeProject,
+    completed: Array.from(completedTech)
+  };
+}
+
+export function setResearchState(data = {}) {
+  researchPoints = data.points || 0;
+  activeProject = data.activeProject || null;
+  completedTech.clear();
+  (data.completed || []).forEach(id => completedTech.add(id));
+  bus.emit('research-updated');
+}
+
+// Periodic passive research point generation in browsers
+if (typeof window !== 'undefined') {
+  setInterval(() => addResearchPoints(1), 30000);
+}
+
+// Hooks for earning research points from gameplay events
+bus.on('quest-completed', () => addResearchPoints(5));
+bus.on('village-founded', () => addResearchPoints(2));

--- a/pirates/ui/commandKeys.js
+++ b/pirates/ui/commandKeys.js
@@ -18,6 +18,7 @@ export function initCommandKeys() {
     <div data-cmd="board" style="display:none">B: Board enemy ship</div>
     <div data-cmd="capture" style="display:none">C: Capture enemy ship</div>
     <div data-cmd="fleet">F: Manage fleet</div>
+    <div data-cmd="research">I: Research</div>
     <div data-cmd="save">S: Save game</div>
     <div data-cmd="load">L: Load game</div>
   `;

--- a/pirates/ui/research.js
+++ b/pirates/ui/research.js
@@ -1,0 +1,59 @@
+import { bus } from '../bus.js';
+import {
+  getResearchNodes,
+  getResearchState,
+  startResearch
+} from '../research.js';
+
+function render() {
+  const menu = document.getElementById('researchMenu');
+  if (!menu || menu.style.display === 'none') return;
+  const state = getResearchState();
+  menu.innerHTML = '';
+
+  const title = document.createElement('div');
+  title.textContent = `Research Points: ${state.points}`;
+  menu.appendChild(title);
+
+  const list = document.createElement('div');
+  getResearchNodes().forEach(node => {
+    const item = document.createElement('div');
+    const btn = document.createElement('button');
+    btn.textContent = node.id;
+    const completed = state.completed.includes(node.id);
+    const active = state.activeProject?.id === node.id;
+    const prereqsMet = node.prerequisites.every(p => state.completed.includes(p));
+    btn.disabled = completed || !prereqsMet || (state.activeProject && !active);
+    btn.onclick = () => startResearch(node.id);
+    item.appendChild(btn);
+    let status = '';
+    if (completed) status = ' (Completed)';
+    else if (active) status = ` (${state.activeProject.progress}/${node.cost})`;
+    else if (!prereqsMet) status = ' (Locked)';
+    else status = ` (Cost: ${node.cost})`;
+    const span = document.createElement('span');
+    span.textContent = status;
+    item.appendChild(span);
+    list.appendChild(item);
+  });
+  menu.appendChild(list);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.onclick = () => (menu.style.display = 'none');
+  menu.appendChild(closeBtn);
+}
+
+export function openResearchMenu() {
+  const menu = document.getElementById('researchMenu');
+  if (!menu) return;
+  menu.style.display = 'block';
+  render();
+}
+
+export function closeResearchMenu() {
+  const menu = document.getElementById('researchMenu');
+  if (menu) menu.style.display = 'none';
+}
+
+bus.on('research-updated', render);


### PR DESCRIPTION
## Summary
- introduce research module with innovation nodes and passive/quest/village point generation
- persist research progress and add UI to manage research tree
- expose research menu via new key and bus events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baa1f24ae8832faca05e96b2adb97c