### PR TITLE
Add tech-tree gating for ships and village upgrades

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -3,11 +3,26 @@ import { Terrain, cartToIso, tileAt } from '../world.js';
 import { Projectile } from './projectile.js';
 import { bus } from '../bus.js';
 import { cartesian } from '../utils/distance.js';
+import { isUnlocked } from '../research.js';
 
 export const SHIP_TYPES = {
   Sloop: { speed: 5, hull: 100, cargo: 20, crew: 10, cost: 0 },
-  Brig: { speed: 4, hull: 150, cargo: 40, crew: 20, cost: 300 },
-  Galleon: { speed: 3, hull: 200, cargo: 60, crew: 40, cost: 600 }
+  Brig: {
+    speed: 4,
+    hull: 150,
+    cargo: 40,
+    crew: 20,
+    cost: 300,
+    tech: 'brigDesign'
+  },
+  Galleon: {
+    speed: 3,
+    hull: 200,
+    cargo: 60,
+    crew: 40,
+    cost: 600,
+    tech: 'galleonDesign'
+  }
 };
 
 export class Ship {
@@ -154,6 +169,11 @@ export class Ship {
   changeType(type) {
     const stats = SHIP_TYPES[type];
     if (!stats) return;
+    const required = stats.tech;
+    if (required && !isUnlocked(required)) {
+      bus.emit('log', `${type} requires ${required} research`);
+      return;
+    }
     this.type = type;
     this.baseMaxSpeed = stats.speed;
     this.maxSpeed = stats.speed;

--- a/pirates/foundVillage.js
+++ b/pirates/foundVillage.js
@@ -1,6 +1,7 @@
 import { Terrain } from './world.js';
 import { City } from './entities/city.js';
 import { bus } from './bus.js';
+import { isUnlocked } from './research.js';
 
 function isIslandLand(t) {
   return (
@@ -115,8 +116,11 @@ export function foundVillage(
   const demands = goods.filter(g => !supplies.includes(g) && rng() < 0.5);
   const production = {};
   const consumption = {};
+  const techBonus = isUnlocked('villageImprovements') ? 1 : 0;
   goods.forEach(g => {
-    production[g] = supplies.includes(g) ? Math.floor(rng() * 3) + 1 : 0;
+    production[g] = supplies.includes(g)
+      ? Math.floor(rng() * 3) + 1 + techBonus
+      : 0;
     consumption[g] = demands.includes(g) ? Math.floor(rng() * 3) + 1 : 0;
   });
   const city = new City(x, y, name, nation);

--- a/pirates/research.js
+++ b/pirates/research.js
@@ -17,6 +17,28 @@ nodes.set(
   new InnovationNode('reinforcedHull', 30, ['improvedSails'], [{ type: 'hull', value: 10 }])
 );
 
+// Village economy improvements add a small production bonus to all goods.
+nodes.set(
+  'villageImprovements',
+  new InnovationNode('villageImprovements', 40, [], [{ type: 'production', value: 0.25 }])
+);
+
+// Unlock additional ship designs for construction.
+nodes.set(
+  'brigDesign',
+  new InnovationNode('brigDesign', 35, [], [{ type: 'ship', value: 'Brig' }])
+);
+nodes.set(
+  'galleonDesign',
+  new InnovationNode('galleonDesign', 60, ['brigDesign'], [{ type: 'ship', value: 'Galleon' }])
+);
+
+// Cannon foundry speeds up reload time and increases damage.
+nodes.set(
+  'cannonFoundry',
+  new InnovationNode('cannonFoundry', 30, [], [{ type: 'cannon', value: 1 }])
+);
+
 export function getResearchNodes() {
   return Array.from(nodes.values());
 }
@@ -60,6 +82,16 @@ function applyResearch() {
     const finished = activeProject.id;
     activeProject = null;
     bus.emit('research-completed', { id: finished });
+    let msg = `${finished} research completed`;
+    if (node.effects) {
+      node.effects.forEach(effect => {
+        if (effect.type === 'ship')
+          msg += `; ${effect.value} class ships available`;
+        if (effect.type === 'cannon') msg += '; cannon performance improved';
+        if (effect.type === 'production') msg += '; village production increased';
+      });
+    }
+    bus.emit('log', msg);
   }
   bus.emit('research-updated');
 }


### PR DESCRIPTION
## Summary
- expand research tree with village improvements, ship designs and cannon foundry
- gate village production, shipyards, and upgrades behind research unlocks
- log research completions and blocked actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa8bd9330832faeb7959b8fb8abbe