### PR TITLE
Enable manual village founding

### DIFF
--- a/pirates/ui/commandKeys.js
+++ b/pirates/ui/commandKeys.js
@@ -16,6 +16,7 @@ export function initCommandKeys() {
     <div data-cmd="upgrade" style="display:none">U: Shipwright</div>
     <div data-cmd="shipyard" style="display:none">Y: Shipyard</div>
     <div data-cmd="board" style="display:none">B: Board enemy ship</div>
+    <div data-cmd="buildVillage" style="display:none">B: Build Village</div>
     <div data-cmd="capture" style="display:none">C: Capture enemy ship</div>
     <div data-cmd="land" style="display:none">Q: Disembark/Board</div>
     <div data-cmd="fleet">F: Manage fleet</div>
@@ -29,7 +30,8 @@ export function updateCommandKeys({
   nearCity = false,
   nearEnemy = false,
   shipyard = false,
-  nearLand = false
+  nearLand = false,
+  canBuildVillage = false
 }) {
   const div = document.getElementById('commandKeys');
   if (!div) return;
@@ -38,7 +40,8 @@ export function updateCommandKeys({
    toggle(div.querySelector('[data-cmd="tavern"]'), nearCity);
    toggle(div.querySelector('[data-cmd="upgrade"]'), nearCity);
   toggle(div.querySelector('[data-cmd="shipyard"]'), shipyard);
-  toggle(div.querySelector('[data-cmd="board"]'), nearEnemy);
+  toggle(div.querySelector('[data-cmd="board"]'), nearEnemy && !canBuildVillage);
+  toggle(div.querySelector('[data-cmd="buildVillage"]'), canBuildVillage);
   toggle(div.querySelector('[data-cmd="capture"]'), nearEnemy);
   toggle(div.querySelector('[data-cmd="land"]'), nearLand);
 }

--- a/test/foundVillage.test.js
+++ b/test/foundVillage.test.js
@@ -2,7 +2,11 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Terrain } from '../pirates/world.js';
 import { drawMinimap } from '../pirates/ui/minimap.js';
-import { foundVillage, computeIslands } from '../pirates/foundVillage.js';
+import {
+  foundVillage,
+  computeIslands,
+  foundVillageAt
+} from '../pirates/foundVillage.js';
 import { City } from '../pirates/entities/city.js';
 import { NpcShip } from '../pirates/entities/npcShip.js';
 import { bus } from '../pirates/bus.js';
@@ -116,4 +120,55 @@ test('cannot found village adjacent to another', () => {
   assert.equal(city, null);
   const villageCount = tiles.flat().filter(t => t === Terrain.VILLAGE).length;
   assert.equal(villageCount, 1);
+});
+
+test('foundVillageAt builds at specified coordinates when valid', () => {
+  const W = Terrain.WATER,
+    C = Terrain.COAST,
+    L = Terrain.LAND;
+  const tiles = [
+    [W, C, W],
+    [W, L, W],
+    [W, C, W]
+  ];
+  const gridSize = 10;
+  const cities = [];
+  const cityMetadata = new Map();
+  const city = foundVillageAt(
+    tiles,
+    gridSize,
+    cities,
+    cityMetadata,
+    'England',
+    GOODS,
+    { r: 0, c: 1 },
+    () => 0
+  );
+  assert.ok(city);
+  assert.equal(tiles[0][1], Terrain.VILLAGE);
+});
+
+test('foundVillageAt rejects invalid site', () => {
+  const V = Terrain.VILLAGE,
+    C = Terrain.COAST,
+    W = Terrain.WATER;
+  const tiles = [
+    [W, V, W],
+    [W, C, W],
+    [W, W, W]
+  ];
+  const gridSize = 10;
+  const cities = [];
+  const cityMetadata = new Map();
+  const city = foundVillageAt(
+    tiles,
+    gridSize,
+    cities,
+    cityMetadata,
+    'England',
+    GOODS,
+    { r: 1, c: 1 },
+    () => 0
+  );
+  assert.equal(city, null);
 });


### PR DESCRIPTION
## Summary
- allow `foundVillage` to place a village at specified coordinates
- add `foundVillageAt` for validating coastal sites
- let land units press **B** to build a village, with UI hint and logging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bad921e850832fbef68c62a84a11ab