### PR TITLE
Allow land units to trade with nearby settlements

### DIFF
--- a/pirates/entities/landUnit.js
+++ b/pirates/entities/landUnit.js
@@ -12,6 +12,7 @@ export class LandUnit {
     this.cargo = {};
     this.cargoCapacity = 20;
     this.gold = 100;
+    this.reputation = {};
     this.inPort = false;
   }
 

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -902,14 +902,18 @@ function loop(timestamp) {
   } else {
     player.inPort = false;
   }
+  const canLandUnitTrade =
+    player instanceof LandUnit &&
+    (metadata?.tribe || metadata?.nation === player.nation);
+  const canTrade = !!nearbyCity && (player instanceof Ship || canLandUnitTrade);
   updateCommandKeys({
-    nearCity: !!nearbyCity,
+    nearCity: canTrade,
     nearEnemy,
     shipyard: !!metadata?.shipyard,
     nearLand,
     canBuildVillage
   });
-  if (nearbyCity) {
+  if (canTrade) {
     if (keys['t'] || keys['T']) {
       closeTradeMenu();
       closeGovernorMenu();

--- a/pirates/ui/commandKeys.js
+++ b/pirates/ui/commandKeys.js
@@ -10,7 +10,7 @@ export function initCommandKeys() {
     <div data-cmd="pause">P: Pause/Unpause</div>
     <div data-cmd="minimap">M: Toggle minimap</div>
     <div data-cmd="sails">1/2/3: Set sails (none/half/full)</div>
-    <div data-cmd="trade" style="display:none">T: Trade (if near a city)</div>
+    <div data-cmd="trade" style="display:none">T: Trade (if near a settlement)</div>
     <div data-cmd="governor" style="display:none">G: Visit governor</div>
     <div data-cmd="tavern" style="display:none">V: Visit tavern</div>
     <div data-cmd="upgrade" style="display:none">U: Shipwright</div>

--- a/pirates/ui/trade.js
+++ b/pirates/ui/trade.js
@@ -37,7 +37,8 @@ export function priceFor(good, metadata, multiplier = 1) {
 }
 
 function cargoUsed(player) {
-  return Object.values(player.cargo).reduce((a, b) => a + b, 0);
+  if (typeof player.cargoUsed === 'function') return player.cargoUsed();
+  return Object.values(player.cargo || {}).reduce((a, b) => a + b, 0);
 }
 
 export function closeTradeMenu() {
@@ -48,6 +49,7 @@ export function closeTradeMenu() {
 export function openTradeMenu(player, city, metadata, priceMultiplier = 1) {
   const menu = document.getElementById('tradeMenu');
   if (!menu || !player) return;
+  player.cargo = player.cargo || {};
 
   if (!metadata?.nation && !metadata?.tribe) {
     bus.emit('log', `Cannot open trade menu for ${city?.name || 'unknown location'}: faction unknown`);
@@ -65,7 +67,8 @@ export function openTradeMenu(player, city, metadata, priceMultiplier = 1) {
   menu.appendChild(goldDiv);
 
   const capacityDiv = document.createElement('div');
-  capacityDiv.textContent = `Cargo: ${cargoUsed(player)}/${player.cargoCapacity}`;
+  const capacity = player.cargoCapacity ?? cargoUsed(player);
+  capacityDiv.textContent = `Cargo: ${cargoUsed(player)}/${capacity}`;
   menu.appendChild(capacityDiv);
 
   const table = document.createElement('table');


### PR DESCRIPTION
## Summary
- Extend `LandUnit` with a reputation field to match trade menu expectations.
- Generalize trade menu to support any unit, calculating cargo usage safely and handling missing capacities.
- Gate trading so land units can trade with natives and villages, and update command key display accordingly.
- Update command key text to mention settlements.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68badbdf9f28832f80f7c655eba47992