### PR TITLE
Ensure world generation meets minimum island count

### DIFF
--- a/pirates/world.js
+++ b/pirates/world.js
@@ -24,7 +24,7 @@ export const Terrain = {
   MISSION: 11
 };
 
-export function generateWorld(width, height, gridSize, options = {}) {
+export function generateWorld(width, height, gridSize, options = {}, _attempt = 0) {
   const {
     seed = Math.random(),
     octaves = 4,
@@ -35,7 +35,8 @@ export function generateWorld(width, height, gridSize, options = {}) {
     hillLevel = 0.6,
     riverThreshold = 0.02,
     temperatureScale = 1,
-    moistureScale = 1
+    moistureScale = 1,
+    maxRetries = 10
   } = options;
 
   const rows = Math.floor(height / gridSize);
@@ -171,6 +172,16 @@ export function generateWorld(width, height, gridSize, options = {}) {
     }
   }
 
+  if (islands.length < 10 && _attempt < maxRetries) {
+    return generateWorld(
+      width,
+      height,
+      gridSize,
+      { ...options, seed: seed + 1 },
+      _attempt + 1
+    );
+  }
+
   const {
     villagesPerIsland = 1,
     villageDensity,
@@ -264,7 +275,7 @@ export function generateWorld(width, height, gridSize, options = {}) {
     }
   }
 
-  return { tiles, rows, cols, villages, natives, missions };
+  return { tiles, rows, cols, villages, natives, missions, islands };
 }
 
 function seededRandom(seed) {

--- a/test/worldVillages.test.js
+++ b/test/worldVillages.test.js
@@ -2,6 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { generateWorld, Terrain } from '../pirates/world.js';
 
+test('generateWorld creates at least 10 islands by default', () => {
+  const { islands } = generateWorld(640, 640, 16, { seed: 1 });
+  assert.ok(
+    islands.length >= 10,
+    `expected at least 10 islands, got ${islands.length}`
+  );
+});
+
 test('generateWorld returns villages with island ids', () => {
   const { villages } = generateWorld(160, 160, 16, { seed: 1, villagesPerIsland: 2 });
   assert.ok(villages.length > 0, 'should create at least one village');


### PR DESCRIPTION
## Summary
- retry world generation with new seeds until at least ten islands form
- expose `maxRetries` option and return island list from `generateWorld`
- add test validating default world creates ten or more islands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68badfdfe664832f98e7e07f835ff6cd