### PR TITLE
feat: limit island size in world generation

### DIFF
--- a/test/worldVillages.test.js
+++ b/test/worldVillages.test.js
@@ -43,3 +43,17 @@ test('villages do not touch each other', () => {
     }
   }
 });
+
+test('generateWorld enforces maxIslandSize', () => {
+  const max = 20;
+  const { islands } = generateWorld(160, 160, 16, {
+    seed: 3,
+    maxIslandSize: max
+  });
+  for (const island of islands) {
+    assert.ok(
+      island.size <= max,
+      `island ${island.id} exceeds max size: ${island.size} > ${max}`
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add `maxIslandSize` option to world generation with erosion of oversized islands
- recompute islands after erosion and place structures accordingly
- test that generated islands never exceed `maxIslandSize`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bafa9202d4832f9d4b79fe755c56f1