### PR TITLE
Ensure NPC spawn count per nation is at least three

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -507,7 +507,12 @@ function setup(options = {}) {
   fleetController = new FleetController(player);
 
   const worldTiles = result.rows * result.cols;
-  const perNation = Math.max(1, Math.floor((worldTiles / 5000) * difficulty));
+  // Ensure at least three NPC ships spawn for each nation by clamping the
+  // per-nation target to a minimum of three.
+  const perNation = Math.max(
+    3,
+    Math.floor((worldTiles / 5000) * difficulty)
+  );
   const targetCounts = {};
   NATIONS.forEach(n => (targetCounts[n] = perNation));
 

--- a/test/npcEconomy.test.js
+++ b/test/npcEconomy.test.js
@@ -41,3 +41,31 @@ test('NPC nations buy ships, paying gold and stock and spawn adjacent', () => {
   const dist = cartesian(ship.x, ship.y, city.x, city.y);
   assert.ok(dist <= gridSize);
 });
+
+// Ensure spawnNpcFromEconomy respects per-nation target counts so nations can
+// field multiple ships when funds and stock allow.
+test('spawnNpcFromEconomy creates ships up to target count', () => {
+  const nations = ['England'];
+  const city = new City(0, 0, 'London', 'England');
+  const cities = [city];
+  const cityMetadata = new Map();
+  cityMetadata.set(city, {
+    nation: 'England',
+    shipyard: { Sloop: { price: 100, stock: 3 } }
+  });
+  const npcShips = [];
+  const targetCounts = { England: 3 };
+  const gridSize = 10;
+  initEconomy(nations, 500);
+
+  spawnNpcFromEconomy(
+    nations,
+    cities,
+    cityMetadata,
+    npcShips,
+    targetCounts,
+    gridSize
+  );
+
+  assert.equal(npcShips.length, 3);
+});


### PR DESCRIPTION
## Summary
- Clamp NPC spawn target per nation to a minimum of three ships
- Verify multiple ships can spawn when target counts exceed one

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb05c85604832f8ea5247e3b8a68f0