### PR TITLE
Add share loot command

### DIFF
--- a/pirates/main.js
+++ b/pirates/main.js
@@ -1123,13 +1123,16 @@ function loop(timestamp) {
     (metadata?.tribe || metadata?.nation === player.nation);
   const canTrade = !!nearbyCity && (player instanceof Ship || canLandUnitTrade);
   const canBuildRoad = player instanceof LandUnit && !!nearbyCity;
+  const canShareLoot =
+    player instanceof Ship && player.gold >= 10 && player.crew > 0;
   updateCommandKeys({
     nearCity: canTrade,
     nearEnemy,
     shipyard: !!metadata?.shipyard,
     nearLand,
     canBuildVillage,
-    canBuildRoad
+    canBuildRoad,
+    canShareLoot
   });
   if (player instanceof LandUnit && (keys['r'] || keys['R'])) {
     if (nearbyCity) {
@@ -1150,6 +1153,12 @@ function loop(timestamp) {
       roadStartCity = null;
     }
     keys['r'] = keys['R'] = false;
+  }
+  if (player instanceof Ship && (keys['h'] || keys['H'])) {
+    if (player.gold >= 10 && player.crew > 0) {
+      player.distributeLoot();
+    }
+    keys['h'] = keys['H'] = false;
   }
   if (canTrade) {
     if (keys['t'] || keys['T']) {

--- a/pirates/ui/commandKeys.js
+++ b/pirates/ui/commandKeys.js
@@ -21,6 +21,7 @@ export function initCommandKeys() {
     <div data-cmd="capture" style="display:none">C: Capture enemy ship</div>
     <div data-cmd="land" style="display:none">Q: Disembark/Board</div>
     <div data-cmd="fleet">F: Manage fleet</div>
+    <div data-cmd="shareLoot" style="display:none">H: Share Loot</div>
     <div data-cmd="research">I: Research</div>
     <div data-cmd="save">S: Save game</div>
     <div data-cmd="load">L: Load game</div>
@@ -33,7 +34,8 @@ export function updateCommandKeys({
   shipyard = false,
   nearLand = false,
   canBuildVillage = false,
-  canBuildRoad = false
+  canBuildRoad = false,
+  canShareLoot = false
 }) {
   const div = document.getElementById('commandKeys');
   if (!div) return;
@@ -47,6 +49,7 @@ export function updateCommandKeys({
   toggle(div.querySelector('[data-cmd="buildRoad"]'), canBuildRoad);
   toggle(div.querySelector('[data-cmd="capture"]'), nearEnemy);
   toggle(div.querySelector('[data-cmd="land"]'), nearLand);
+  toggle(div.querySelector('[data-cmd="shareLoot"]'), canShareLoot);
 }
 
 function toggle(el, show) {


### PR DESCRIPTION
## Summary
- Add Share Loot command to UI and toggle based on available gold/crew
- Handle H key to distribute loot when player is a ship

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb327e7964832fa8a65eaa70515caa