### PR TITLE
Render coast tiles and distinguish them on the minimap

### DIFF
--- a/pirates/assets.js
+++ b/pirates/assets.js
@@ -24,6 +24,9 @@ export async function loadAssets(tileSize){
     if (!assets.tiles.mission) {
       assets.tiles.mission = assets.tiles.village;
     }
+    if (!assets.tiles.coast) {
+      assets.tiles.coast = assets.tiles.land;
+    }
     ensureFlags();
     const sampleTile = assets.tiles && Object.values(assets.tiles)[0];
     const tileWidth = sampleTile?.tileWidth || sampleTile?.width || gridSize;

--- a/pirates/ui/minimap.js
+++ b/pirates/ui/minimap.js
@@ -18,16 +18,18 @@ export function drawMinimap(
   ctx.clearRect(0, 0, width, height);
   ctx.fillStyle = '#0af';
   ctx.fillRect(0, 0, width, height);
-  ctx.fillStyle = '#070';
+  const landColor = '#070';
+  const coastColor = '#c90';
   const isWater = t =>
     t === Terrain.WATER || t === Terrain.RIVER || t === Terrain.REEF;
   for (let r = 0; r < tiles.length; r++) {
     for (let c = 0; c < tiles[0].length; c++) {
-      if (!isWater(tiles[r][c])) {
-        const x = (c / tiles[0].length) * width;
-        const y = (r / tiles.length) * height;
-        ctx.fillRect(x, y, width / tiles[0].length, height / tiles.length);
-      }
+      const t = tiles[r][c];
+      if (isWater(t)) continue;
+      const x = (c / tiles[0].length) * width;
+      const y = (r / tiles.length) * height;
+      ctx.fillStyle = t === Terrain.COAST ? coastColor : landColor;
+      ctx.fillRect(x, y, width / tiles[0].length, height / tiles.length);
     }
   }
   // Draw city markers

--- a/pirates/world.js
+++ b/pirates/world.js
@@ -585,7 +585,8 @@ export function drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight,
       else if (t === Terrain.MISSION) img = assets.tiles?.mission || assets.tiles?.village;
       else if (t === Terrain.NATIVE) img = assets.tiles?.native || assets.tiles?.village;
       else if (t === Terrain.ROAD) img = assets.tiles?.road || assets.tiles?.land;
-      else if (t === Terrain.COAST || t === Terrain.REEF) img = assets.tiles?.coast || assets.tiles?.land;
+      else if (t === Terrain.COAST) img = assets.tiles?.coast || assets.tiles?.land;
+      else if (t === Terrain.REEF) img = assets.tiles?.reef || assets.tiles?.water;
       else img = assets.tiles?.land;
       if (!img) continue;
       const { x, y } = worldToIso(r, c, tileWidth, tileIsoHeight, tileImageHeight, isoX, isoY);


### PR DESCRIPTION
## Summary
- draw coast tiles using a dedicated asset when available, falling back to land if missing
- color coast tiles brown on the minimap for clarity
- remove the committed coast tile PNG asset and its manifest entry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbcc7f3764832f829d47cf509582d7