### PR TITLE
Add ship direction and sprite fallback tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ Node server is included. It serves files without adding any
 node server.js
 ```
 
+## Asset structure and directional sprites
+
+Ship graphics are defined in `pirates/assets.json` under a hierarchy of ship
+`type`, `nation` and compass `direction`. Each nation may provide images for the
+eight directions (`E`, `SE`, `S`, `SW`, `W`, `NW`, `N`, `NE`) as well as a
+`default` sprite. The `getShipSprite` helper resolves a sprite by searching for
+the requested direction first, then falling back to the nation's `default`
+image and finally the type's own `default` entry. When no matching asset is
+found a simple placeholder is generated. A ship's `angle` is normalised to one
+of the eight direction keys, ensuring the correct sprite is selected as it
+turns.
+
 ## Isometric coordinates and camera
 
 The `pirates` demo renders its world using an isometric projection where

--- a/test/shipSprites.test.js
+++ b/test/shipSprites.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Ship } from '../pirates/entities/ship.js';
+import { getShipSprite, assets } from '../pirates/assets.js';
+
+const DIRS = ['E', 'SE', 'S', 'SW', 'W', 'NW', 'N', 'NE'];
+
+// Test that setting angles updates the ship heading to the expected direction key.
+test('Ship resolves direction key from angle', () => {
+  const ship = new Ship(0, 0);
+  const cases = [
+    [0, 'E'],
+    [Math.PI / 4, 'SE'],
+    [Math.PI / 2, 'S'],
+    [(3 * Math.PI) / 4, 'SW'],
+    [Math.PI, 'W'],
+    [(5 * Math.PI) / 4, 'NW'],
+    [(3 * Math.PI) / 2, 'N'],
+    [(7 * Math.PI) / 4, 'NE'],
+    [-Math.PI / 4, 'NE'], // negative angle wraps correctly
+  ];
+
+  for (const [angle, expected] of cases) {
+    ship.angle = angle;
+    assert.equal(DIRS[ship.heading], expected, `angle ${angle} -> ${expected}`);
+  }
+});
+
+// Test that getShipSprite falls back to a default sprite when a direction is missing.
+test('getShipSprite falls back to default direction sprite', () => {
+  const originalShip = assets.ship;
+  try {
+    assets.ship = {
+      TestType: {
+        TestNation: {
+          default: 'DEFAULT_SPRITE',
+        },
+      },
+    };
+
+    const sprite = getShipSprite('TestType', 'TestNation', 'N');
+    assert.equal(sprite, 'DEFAULT_SPRITE');
+  } finally {
+    assets.ship = originalShip;
+  }
+});


### PR DESCRIPTION
## Summary
- add unit tests for ship angle-to-direction mapping
- verify getShipSprite falls back to default when direction missing
- document asset hierarchy and sprite resolution in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbd5d8d4a0832fbf11474298d22e56