### PR TITLE
Support additional terrain tiles and minimap colors

### DIFF
--- a/pirates/assets.js
+++ b/pirates/assets.js
@@ -27,6 +27,24 @@ export async function loadAssets(tileSize){
     if (!assets.tiles.coast) {
       assets.tiles.coast = assets.tiles.land;
     }
+    if (!assets.tiles.native) {
+      assets.tiles.native = assets.tiles.village;
+    }
+    if (!assets.tiles.road) {
+      assets.tiles.road = assets.tiles.land;
+    }
+    if (!assets.tiles.reef) {
+      assets.tiles.reef = assets.tiles.water;
+    }
+    if (!assets.tiles.river) {
+      assets.tiles.river = assets.tiles.water;
+    }
+    if (!assets.tiles.desert) {
+      assets.tiles.desert = assets.tiles.land;
+    }
+    if (!assets.tiles.forest) {
+      assets.tiles.forest = assets.tiles.land;
+    }
     ensureFlags();
     const sampleTile = assets.tiles && Object.values(assets.tiles)[0];
     const tileWidth = sampleTile?.tileWidth || sampleTile?.width || gridSize;

--- a/pirates/assets.json
+++ b/pirates/assets.json
@@ -4,7 +4,14 @@
     "land": "assets/grassTB128.png",
     "village": "assets/villageTB128.png",
     "hill": "assets/hillTB128.png",
-    "mission": "assets/villageTB128.png"
+    "mission": "assets/villageTB128.png",
+    "native": "assets/nativeTB128.png",
+    "road": "assets/roadTB128.png",
+    "coast": "assets/coastTB128.png",
+    "reef": "assets/reefTB128.png",
+    "river": "assets/riverTB128.png",
+    "desert": "assets/desertTB128.png",
+    "forest": "assets/forestTB128.png"
   },
   "ship": {
     "Sloop": {

--- a/pirates/ui/minimap.js
+++ b/pirates/ui/minimap.js
@@ -20,15 +20,24 @@ export function drawMinimap(
   ctx.fillRect(0, 0, width, height);
   const landColor = '#070';
   const coastColor = '#c90';
-  const isWater = t =>
-    t === Terrain.WATER || t === Terrain.RIVER || t === Terrain.REEF;
+  const desertColor = '#edc';
+  const forestColor = '#040';
+  const riverColor = '#05f';
+  const roadColor = '#aaa';
+  const isWater = t => t === Terrain.WATER || t === Terrain.REEF;
   for (let r = 0; r < tiles.length; r++) {
     for (let c = 0; c < tiles[0].length; c++) {
       const t = tiles[r][c];
       if (isWater(t)) continue;
       const x = (c / tiles[0].length) * width;
       const y = (r / tiles.length) * height;
-      ctx.fillStyle = t === Terrain.COAST ? coastColor : landColor;
+      let color = landColor;
+      if (t === Terrain.COAST) color = coastColor;
+      else if (t === Terrain.DESERT) color = desertColor;
+      else if (t === Terrain.FOREST) color = forestColor;
+      else if (t === Terrain.RIVER) color = riverColor;
+      else if (t === Terrain.ROAD) color = roadColor;
+      ctx.fillStyle = color;
       ctx.fillRect(x, y, width / tiles[0].length, height / tiles.length);
     }
   }

--- a/pirates/world.js
+++ b/pirates/world.js
@@ -579,8 +579,11 @@ export function drawWorld(ctx, tiles, tileWidth, tileIsoHeight, tileImageHeight,
     for (let c = firstCol; c <= lastCol; c++) {
       const t = tiles[r][c];
       let img;
-      if (t === Terrain.WATER || t === Terrain.RIVER) img = assets.tiles?.water;
+      if (t === Terrain.WATER) img = assets.tiles?.water;
+      else if (t === Terrain.RIVER) img = assets.tiles?.river || assets.tiles?.water;
       else if (t === Terrain.HILL) img = assets.tiles?.hill;
+      else if (t === Terrain.DESERT) img = assets.tiles?.desert || assets.tiles?.land;
+      else if (t === Terrain.FOREST) img = assets.tiles?.forest || assets.tiles?.land;
       else if (t === Terrain.VILLAGE) img = assets.tiles?.village;
       else if (t === Terrain.MISSION) img = assets.tiles?.mission || assets.tiles?.village;
       else if (t === Terrain.NATIVE) img = assets.tiles?.native || assets.tiles?.village;


### PR DESCRIPTION
## Summary
- Register new terrain tile images in the asset manifest
- Provide fallbacks for missing tile images when loading assets
- Render rivers, deserts, and forests with dedicated sprites and minimap colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbdc0aabc8832fbf97c9e4d20b7a7c