### PR TITLE
Add dynamic storms with ship penalties and weather overlay

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -87,6 +87,7 @@ export class Ship {
     this.ramCooldown = 0;
     this.ramRate = 120;
     this.updateAppearance();
+    this.stormDamageTimer = 0;
   }
 
   get angle() {
@@ -103,7 +104,7 @@ export class Ship {
   }
 
   forward(dt) {
-    const wind = Ship.wind || { speed: 0, angle: 0 };
+    const wind = this.wind || Ship.wind || { speed: 0, angle: 0 };
     const rel = wind.angle - this.angle;
     const windAlong = Math.cos(rel) * wind.speed * this.sail;
     const windSide = Math.sin(rel) * wind.speed * this.sail;
@@ -137,6 +138,20 @@ export class Ship {
     this.adjustMorale(-moraleLoss);
 
     this.checkMutiny();
+
+    if (this.inStorm) {
+      const intensity = this.stormIntensity || 0.5;
+      this.maxSpeed = this.baseMaxSpeed * (1 - intensity * 0.3);
+      this.speed = Math.min(this.speed, this.maxSpeed);
+      this.stormDamageTimer += dt;
+      if (this.stormDamageTimer > 60) {
+        this.takeDamage(5 * intensity);
+        this.stormDamageTimer = 0;
+      }
+    } else {
+      this.maxSpeed = this.baseMaxSpeed;
+      this.stormDamageTimer = 0;
+    }
 
     const { x: dx, y: dy } = this.forward(dt);
     let newX = this.x + dx;

--- a/pirates/ui/weatherOverlay.js
+++ b/pirates/ui/weatherOverlay.js
@@ -1,0 +1,76 @@
+import { cartToIso } from '../world.js';
+
+export function drawWeatherOverlay(
+  ctx,
+  storms = [],
+  wind,
+  offsetX = 0,
+  offsetY = 0,
+  tileWidth = 0,
+  tileIsoHeight = 0,
+  tileImageHeight = 0
+) {
+  if (!ctx) return;
+  ctx.save();
+  storms.forEach(s => {
+    const { isoX, isoY } = cartToIso(
+      s.x,
+      s.y,
+      tileWidth,
+      tileIsoHeight,
+      tileImageHeight
+    );
+    ctx.fillStyle = `rgba(100,100,100,${0.2 + 0.3 * s.intensity})`;
+    ctx.beginPath();
+    ctx.arc(isoX - offsetX, isoY - offsetY, s.radius, 0, Math.PI * 2);
+    ctx.fill();
+  });
+  if (wind) {
+    const len = 40;
+    const cx = 50;
+    const cy = 50;
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(cx + Math.cos(wind.angle) * len, cy + Math.sin(wind.angle) * len);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(cx, cy, 4, 0, Math.PI * 2);
+    ctx.fillStyle = '#fff';
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+export function drawWeatherMinimap(
+  ctx,
+  storms = [],
+  wind,
+  worldWidth,
+  worldHeight
+) {
+  if (!ctx) return;
+  ctx.save();
+  storms.forEach(s => {
+    const x = (s.x / worldWidth) * ctx.canvas.width;
+    const y = (s.y / worldHeight) * ctx.canvas.height;
+    const r = (s.radius / worldWidth) * ctx.canvas.width;
+    ctx.fillStyle = 'rgba(100,100,100,0.5)';
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.fill();
+  });
+  if (wind) {
+    const len = 15;
+    const cx = ctx.canvas.width - 20;
+    const cy = ctx.canvas.height - 20;
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(cx + Math.cos(wind.angle) * len, cy + Math.sin(wind.angle) * len);
+    ctx.stroke();
+  }
+  ctx.restore();
+}


### PR DESCRIPTION
## Summary
- Generate storm cells and adjust per-ship wind & visibility with `storm-start`/`storm-end` events
- Apply storm speed penalties and periodic hull damage to ships
- Render storm clouds and wind direction on game canvas and minimap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc3c42880c832fabd1b4bbd0cf0d45