### PR TITLE
Add crew hiring and wage mechanics

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -76,6 +76,11 @@ export class Ship {
     this.inPort = false;
     this.mutinied = false;
 
+    // wages
+    this.wageRate = 1; // gold per crew per day
+    this.unpaidWages = 0;
+    this.lastPaid = Date.now();
+
     // cannon fire control
     this.fireCooldown = 0; // frames until next shot allowed
     this.baseFireRate = 30; // base cooldown frames between shots
@@ -350,6 +355,21 @@ export class Ship {
     if (this.crew <= 0 && !this.mutinied) {
       this.mutinied = true;
       bus.emit('log', 'Your crew has taken the ship! Game over.');
+    }
+  }
+
+  processPayroll() {
+    const due = this.crew * this.wageRate;
+    if (due <= 0) return;
+    if (this.gold >= due) {
+      this.gold -= due;
+      this.unpaidWages = 0;
+      this.lastPaid = Date.now();
+    } else {
+      const deficit = due - this.gold;
+      this.gold = 0;
+      this.unpaidWages += deficit;
+      this.adjustMorale(-5);
     }
   }
 

--- a/pirates/index.html
+++ b/pirates/index.html
@@ -100,7 +100,8 @@
     #fleetMenu,
     #shipyardMenu,
     #researchMenu,
-    #diplomacyMenu {
+    #diplomacyMenu,
+    #crewMenu {
       position: absolute;
       top: 50%;
       left: 50%;
@@ -167,6 +168,7 @@
   <div id="fleetMenu"></div>
   <div id="researchMenu"></div>
   <div id="diplomacyMenu"></div>
+  <div id="crewMenu"></div>
   <div id="cardContainer" class="isometric-cards"></div>
 
     <script type="module" src="main.js"></script>

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -251,7 +251,11 @@ function updateWind() {
 }
 setInterval(updateWind, 10000);
 updateWind();
-setInterval(updateMarkets, DAY_MS);
+function dailyTick() {
+  updateMarkets();
+  runPayroll();
+}
+setInterval(dailyTick, DAY_MS);
 
 function applyStormEffects(ship) {
   if (!ship) return;
@@ -438,6 +442,19 @@ function attemptFoundVillages() {
       econ.gold -= 500;
     }
   });
+}
+
+function runPayroll() {
+  const ships = [];
+  if (player?.fleet) ships.push(...player.fleet);
+  if (npcShips) ships.push(...npcShips);
+  ships.forEach(s => {
+    if (s.processPayroll) {
+      s.processPayroll();
+      if (s.checkMutiny) s.checkMutiny();
+    }
+  });
+  if (player) updateHUD(player, wind);
 }
 
 function spawnVillageNpcShip(city, nation, npcShips, targetCounts) {

--- a/pirates/ui/crew.js
+++ b/pirates/ui/crew.js
@@ -1,14 +1,13 @@
 import { bus } from '../bus.js';
 import { updateHUD } from './hud.js';
-import { openCrewMenu } from './crew.js';
 
-export function openTavernMenu(player, city) {
-  const menu = document.getElementById('tavernMenu');
+export function openCrewMenu(player) {
+  const menu = document.getElementById('crewMenu');
   if (!menu) return;
   menu.innerHTML = '';
 
   const title = document.createElement('div');
-  title.textContent = city?.name ? `Tavern in ${city.name}` : 'Tavern';
+  title.textContent = 'Crew Management';
   menu.appendChild(title);
 
   const goldDiv = document.createElement('div');
@@ -18,13 +17,40 @@ export function openTavernMenu(player, city) {
   const crewDiv = document.createElement('div');
   crewDiv.textContent = `Crew: ${player.crew}/${player.crewMax}`;
   menu.appendChild(crewDiv);
+
+  const wageDiv = document.createElement('div');
+  wageDiv.textContent = `Wage Rate: ${player.wageRate}g/day`;
+  menu.appendChild(wageDiv);
+
+  const unpaidDiv = document.createElement('div');
+  unpaidDiv.textContent = `Unpaid Wages: ${player.unpaidWages}`;
+  menu.appendChild(unpaidDiv);
+
+  const wageContainer = document.createElement('div');
+  const wageInput = document.createElement('input');
+  wageInput.type = 'number';
+  wageInput.min = 0;
+  wageInput.value = player.wageRate;
+  const wageBtn = document.createElement('button');
+  wageBtn.textContent = 'Set Wage Rate';
+  wageBtn.onclick = () => {
+    const rate = parseFloat(wageInput.value);
+    if (!isNaN(rate) && rate >= 0) {
+      player.wageRate = rate;
+      openCrewMenu(player);
+    }
+  };
+  wageContainer.appendChild(wageInput);
+  wageContainer.appendChild(wageBtn);
+  menu.appendChild(wageContainer);
+
   const hireContainer = document.createElement('div');
   const hireInput = document.createElement('input');
   hireInput.type = 'number';
   hireInput.min = 1;
   hireInput.value = 1;
   const hireBtn = document.createElement('button');
-  hireBtn.textContent = 'Hire crew (20g ea)';
+  hireBtn.textContent = 'Hire (20g ea)';
 
   const updateControls = () => {
     const maxByGold = Math.floor(player.gold / 20);
@@ -44,37 +70,27 @@ export function openTavernMenu(player, city) {
       player.gold -= cost;
       player.crew += qty;
       player.updateCrewStats && player.updateCrewStats();
-      bus.emit(
-        'log',
-        `Hired ${qty} crew member${qty !== 1 ? 's' : ''} for ${cost}g`
-      );
+      bus.emit('log', `Hired ${qty} crew for ${cost}g`);
       updateHUD(player);
-      openTavernMenu(player, city);
+      openCrewMenu(player);
     }
   };
 
   updateControls();
-
   hireContainer.appendChild(hireInput);
   hireContainer.appendChild(hireBtn);
   menu.appendChild(hireContainer);
 
-  const manageBtn = document.createElement('button');
-  manageBtn.textContent = 'Manage Crew';
-  manageBtn.onclick = () => openCrewMenu(player);
-  menu.appendChild(manageBtn);
-
   const closeBtn = document.createElement('button');
   closeBtn.textContent = 'Close';
-  closeBtn.onclick = () => {
-    menu.style.display = 'none';
-  };
+  closeBtn.onclick = closeCrewMenu;
   menu.appendChild(closeBtn);
 
   menu.style.display = 'block';
 }
 
-export function closeTavernMenu() {
-  const menu = document.getElementById('tavernMenu');
+export function closeCrewMenu() {
+  const menu = document.getElementById('crewMenu');
   if (menu) menu.style.display = 'none';
 }
+

--- a/pirates/ui/governor.js
+++ b/pirates/ui/governor.js
@@ -2,6 +2,7 @@ import { bus } from '../bus.js';
 import { questManager } from '../questManager.js';
 import { Quest } from '../quest.js';
 import { updateHUD } from './hud.js';
+import { openCrewMenu } from './crew.js';
 
 const NATIONS = ['England', 'France', 'Spain', 'Netherlands'];
 
@@ -36,6 +37,11 @@ export function openGovernorMenu(player, city, metadata) {
     menu.style.display = 'none';
   };
   menu.appendChild(missionBtn);
+
+  const crewBtn = document.createElement('button');
+  crewBtn.textContent = 'Crew';
+  crewBtn.onclick = () => openCrewMenu(player);
+  menu.appendChild(crewBtn);
 
   // diplomacy controls
   const diplomacyDiv = document.createElement('div');


### PR DESCRIPTION
## Summary
- Add crew management UI for hiring and wage rate adjustments
- Track wage obligations on ships and process daily payroll with morale effects
- Hook crew tools into tavern and governor menus and update tavern hiring logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc6ca12a20832f9d7e2ad4ac1bc785