### PR TITLE
Add trade routes with automation and persistence

### DIFF
--- a/pirates/entities/ship.js
+++ b/pirates/entities/ship.js
@@ -158,6 +158,23 @@ export class Ship {
       this.stormDamageTimer = 0;
     }
 
+    if (this.routeTarget) {
+      const desired = Math.atan2(
+        this.routeTarget.y - this.y,
+        this.routeTarget.x - this.x
+      );
+      this.angle = desired;
+      const dist = Math.hypot(
+        this.routeTarget.x - this.x,
+        this.routeTarget.y - this.y
+      );
+      if (dist > 10) {
+        this.speed = Math.min(this.speed + 0.05 * dt, this.maxSpeed);
+      } else {
+        this.speed = Math.max(this.speed - 0.1 * dt, 0);
+      }
+    }
+
     const { x: dx, y: dy } = this.forward(dt);
     let newX = this.x + dx;
     let newY = this.y + dy;

--- a/pirates/fleet.js
+++ b/pirates/fleet.js
@@ -1,3 +1,5 @@
+import { getRoute, autoTrade } from './tradeRoutes.js';
+
 export class FleetController {
   constructor(flagship) {
     this.flagship = flagship;
@@ -26,7 +28,15 @@ export class FleetController {
     });
   }
 
-  update(dt, tiles, gridSize, worldWidth, worldHeight) {
+  update(
+    dt,
+    tiles,
+    gridSize,
+    worldWidth,
+    worldHeight,
+    cities = [],
+    cityMetadata = new Map()
+  ) {
     const fleet = this.flagship?.fleet;
     if (!fleet) return;
     if (fleet.length !== this._lastCount) {
@@ -38,6 +48,7 @@ export class FleetController {
     const sin = Math.sin(leader.angle);
     for (let i = 1; i < fleet.length; i++) {
       const ship = fleet[i];
+      if (getRoute(ship)) continue; // routed ships handle their own movement
       const off = ship.formationOffset || { x: 0, y: 0 };
       const targetX = leader.x + cos * off.x - sin * off.y;
       const targetY = leader.y + sin * off.x + cos * off.y;
@@ -50,6 +61,27 @@ export class FleetController {
         ship.speed = Math.max(ship.speed - 0.1 * dt, 0);
       }
     }
-    fleet.forEach(s => s.update(dt, tiles, gridSize, worldWidth, worldHeight));
+
+    fleet.forEach(s => {
+      const route = getRoute(s);
+      if (route && route.cities.length) {
+        const target = route.cities[route.index % route.cities.length];
+        if (target) {
+          s.routeTarget = { x: target.x, y: target.y };
+          const dist = Math.hypot(target.x - s.x, target.y - s.y);
+          if (dist < gridSize) {
+            const metadata = cityMetadata.get(target);
+            if (metadata) autoTrade(s, target, metadata, route);
+            route.index = (route.index + 1) % route.cities.length;
+            const next = route.cities[route.index % route.cities.length];
+            s.routeTarget = next ? { x: next.x, y: next.y } : null;
+            s.visitPort?.();
+          }
+        }
+      } else {
+        s.routeTarget = null;
+      }
+      s.update(dt, tiles, gridSize, worldWidth, worldHeight);
+    });
   }
 }

--- a/pirates/main.js
+++ b/pirates/main.js
@@ -54,6 +54,7 @@ import {
   drawWeatherOverlay,
   drawWeatherMinimap
 } from './ui/weatherOverlay.js';
+import { serializeRoutes, deserializeRoutes } from './tradeRoutes.js';
 
 let worldWidth, worldHeight, gridSize, tileWidth, tileIsoHeight, tileImageHeight;
 const CSS_WIDTH = 800, CSS_HEIGHT = 600;
@@ -791,6 +792,7 @@ function saveGame() {
     effect: e.effect,
     duration: e.duration
   }));
+  const routeData = serializeRoutes(player.fleet || []);
 
   const data = {
     version: SAVE_VERSION,
@@ -803,7 +805,8 @@ function saveGame() {
     quests,
     priceEvents: priceData,
     seasonalEvents: seasonalData,
-    research: getResearchState()
+    research: getResearchState(),
+    tradeRoutes: routeData
   };
   try {
     localStorage.setItem('pirates-save', JSON.stringify(data));
@@ -858,6 +861,8 @@ function loadGame() {
         cityMetadata.set(city, meta);
       });
     }
+
+    deserializeRoutes(data.tradeRoutes || [], player.fleet, cities);
 
     // Rebuild NPC ships
     npcShips = (data.npcShips || []).map(n => {
@@ -1053,7 +1058,15 @@ function loop(timestamp) {
   // Storm effects for player fleet
   if (player.fleet) player.fleet.forEach(applyStormEffects);
   // Update all player ships via fleet controller
-  fleetController.update(dt, tiles, gridSize, worldWidth, worldHeight);
+  fleetController.update(
+    dt,
+    tiles,
+    gridSize,
+    worldWidth,
+    worldHeight,
+    cities,
+    cityMetadata
+  );
 
   if (!(player instanceof Ship)) {
     player.update(dt, tiles, gridSize, worldWidth, worldHeight);

--- a/pirates/tradeRoutes.js
+++ b/pirates/tradeRoutes.js
@@ -1,0 +1,117 @@
+// Trade route management for automated trading ships
+// Stores route definitions and provides serialization hooks
+
+const routes = new Map(); // ship -> route
+
+// route structure: {
+//   cities: [City],        // ordered list of city objects
+//   buy: [string],         // goods to buy
+//   sell: [string],        // goods to sell
+//   index: 0               // current waypoint index
+// }
+
+export function setRoute(ship, route) {
+  if (!ship || !route || !route.cities || route.cities.length === 0) return;
+  route.index = route.index || 0;
+  routes.set(ship, route);
+}
+
+export function getRoute(ship) {
+  return routes.get(ship);
+}
+
+export function clearRoute(ship) {
+  routes.delete(ship);
+}
+
+// Serialization of routes for saving
+export function serializeRoutes(fleet) {
+  const data = [];
+  routes.forEach((route, ship) => {
+    const idx = fleet.indexOf(ship);
+    if (idx === -1) return;
+    data.push({
+      shipIndex: idx,
+      cities: route.cities.map(c => c.name),
+      buy: route.buy || [],
+      sell: route.sell || [],
+      index: route.index || 0
+    });
+  });
+  return data;
+}
+
+export function deserializeRoutes(data, fleet, cities) {
+  routes.clear();
+  data.forEach(entry => {
+    const ship = fleet[entry.shipIndex];
+    if (!ship) return;
+    const routeCities = (entry.cities || [])
+      .map(name => cities.find(c => c.name === name))
+      .filter(Boolean);
+    if (routeCities.length) {
+      routes.set(ship, {
+        cities: routeCities,
+        buy: entry.buy || [],
+        sell: entry.sell || [],
+        index: entry.index || 0
+      });
+    }
+  });
+}
+
+// Execute automatic trading for a ship at a city
+import { priceFor } from './ui/trade.js';
+import { bus } from './bus.js';
+
+function cargoUsed(ship) {
+  return Object.values(ship.cargo || {}).reduce((a, b) => a + b, 0);
+}
+
+export function autoTrade(ship, city, metadata, route) {
+  if (!ship || !city || !metadata || !route) return;
+  metadata.inventory = metadata.inventory || {};
+  metadata.prices = metadata.prices || {};
+
+  // Buying goods
+  (route.buy || []).forEach(good => {
+    if (metadata.inventory[good] == null) metadata.inventory[good] = 10;
+    const price = priceFor(good, metadata);
+    while (
+      ship.gold >= price &&
+      metadata.inventory[good] > 0 &&
+      cargoUsed(ship) < ship.cargoCapacity
+    ) {
+      ship.gold -= price;
+      ship.cargo[good] = (ship.cargo[good] || 0) + 1;
+      metadata.inventory[good] -= 1;
+      const oldPrice = metadata.prices[good];
+      metadata.prices[good] = Math.round(oldPrice * 1.1);
+      bus.emit('log', `${ship.type} bought 1 ${good} in ${city.name}`);
+    }
+  });
+
+  // Selling goods
+  (route.sell || []).forEach(good => {
+    if (metadata.inventory[good] == null) metadata.inventory[good] = 10;
+    const sellPrice = Math.floor(priceFor(good, metadata) * 0.9);
+    while (ship.cargo[good] > 0) {
+      ship.cargo[good] -= 1;
+      ship.gold += sellPrice;
+      metadata.inventory[good] += 1;
+      const oldPrice = metadata.prices[good];
+      metadata.prices[good] = Math.max(1, Math.round(oldPrice * 0.9));
+      bus.emit('log', `${ship.type} sold 1 ${good} in ${city.name}`);
+    }
+    if (ship.cargo[good] <= 0) delete ship.cargo[good];
+  });
+}
+
+export default {
+  setRoute,
+  getRoute,
+  clearRoute,
+  serializeRoutes,
+  deserializeRoutes,
+  autoTrade
+};

--- a/pirates/ui/fleet.js
+++ b/pirates/ui/fleet.js
@@ -1,92 +1,191 @@
 import { bus } from '../bus.js';
 import { updateHUD } from './hud.js';
+import { setRoute, getRoute, clearRoute } from '../tradeRoutes.js';
 
 export function openFleetMenu(player) {
   const div = document.getElementById('fleetMenu');
   if (!div) return;
   div.innerHTML = '';
-  player.fleet.forEach((ship, idx) => {
-    const shipDiv = document.createElement('div');
-    shipDiv.textContent = `${ship.type} - Crew: ${ship.crew} Hull: ${ship.hull}/${ship.hullMax}`;
-    if (ship === player) {
-      const span = document.createElement('span');
-      span.textContent = ' (Flagship)';
-      shipDiv.appendChild(span);
-    } else {
-      const flagBtn = document.createElement('button');
-      flagBtn.textContent = 'Make Flagship';
-      flagBtn.onclick = () => {
-        bus.emit('switch-flagship', { ship });
-        closeFleetMenu();
-      };
-      shipDiv.appendChild(flagBtn);
 
-      const crewBtn = document.createElement('button');
-      crewBtn.textContent = 'Transfer Crew';
-      crewBtn.onclick = () => {
-        const amt = parseInt(
-          prompt('Crew amount (positive to transfer from flagship, negative for reverse):'),
-          10
-        );
-        if (isNaN(amt) || amt === 0) return;
-        if (amt > 0 && player.crew >= amt) {
-          player.crew -= amt;
-          ship.crew += amt;
-        } else if (amt < 0 && ship.crew >= -amt) {
-          ship.crew += amt;
-          player.crew -= amt;
-        } else {
-          alert('Insufficient crew');
-          return;
-        }
-        ship.updateCrewStats();
-        player.updateCrewStats();
-        updateHUD(player);
-      };
-      shipDiv.appendChild(crewBtn);
+  const tabs = document.createElement('div');
+  const fleetBtn = document.createElement('button');
+  fleetBtn.textContent = 'Fleet';
+  const routeBtn = document.createElement('button');
+  routeBtn.textContent = 'Trade Route';
+  tabs.appendChild(fleetBtn);
+  tabs.appendChild(routeBtn);
+  div.appendChild(tabs);
 
-      const cargoBtn = document.createElement('button');
-      cargoBtn.textContent = 'Transfer Cargo';
-      cargoBtn.onclick = () => {
-        const good = prompt('Good to transfer:');
-        if (!good) return;
-        const amt = parseInt(
-          prompt('Amount (positive from flagship to ship, negative for reverse):'),
-          10
-        );
-        if (isNaN(amt) || amt === 0) return;
-        const from = amt > 0 ? player : ship;
-        const to = amt > 0 ? ship : player;
-        const quantity = Math.abs(amt);
-        if ((from.cargo[good] || 0) < quantity) {
-          alert('Not enough goods');
-          return;
-        }
-        const used = Object.values(to.cargo).reduce((a, b) => a + b, 0);
-        if (amt > 0 && used + quantity > to.cargoCapacity) {
-          alert('No space');
-          return;
-        }
-        from.cargo[good] -= quantity;
-        if (from.cargo[good] <= 0) delete from.cargo[good];
-        to.cargo[good] = (to.cargo[good] || 0) + quantity;
-        updateHUD(player);
-      };
-      shipDiv.appendChild(cargoBtn);
+  const content = document.createElement('div');
+  div.appendChild(content);
 
-      const dismissBtn = document.createElement('button');
-      dismissBtn.textContent = 'Dismiss';
-      dismissBtn.onclick = () => {
-        if (confirm('Dismiss this ship?')) {
-          const index = player.fleet.indexOf(ship);
-          if (index !== -1) player.fleet.splice(index, 1);
+  function renderFleetTab() {
+    content.innerHTML = '';
+    player.fleet.forEach(ship => {
+      const shipDiv = document.createElement('div');
+      shipDiv.textContent = `${ship.type} - Crew: ${ship.crew} Hull: ${ship.hull}/${ship.hullMax}`;
+      if (ship === player) {
+        const span = document.createElement('span');
+        span.textContent = ' (Flagship)';
+        shipDiv.appendChild(span);
+      } else {
+        const flagBtn = document.createElement('button');
+        flagBtn.textContent = 'Make Flagship';
+        flagBtn.onclick = () => {
+          bus.emit('switch-flagship', { ship });
           closeFleetMenu();
-        }
-      };
-      shipDiv.appendChild(dismissBtn);
+        };
+        shipDiv.appendChild(flagBtn);
+
+        const crewBtn = document.createElement('button');
+        crewBtn.textContent = 'Transfer Crew';
+        crewBtn.onclick = () => {
+          const amt = parseInt(
+            prompt('Crew amount (positive to transfer from flagship, negative for reverse):'),
+            10
+          );
+          if (isNaN(amt) || amt === 0) return;
+          if (amt > 0 && player.crew >= amt) {
+            player.crew -= amt;
+            ship.crew += amt;
+          } else if (amt < 0 && ship.crew >= -amt) {
+            ship.crew += amt;
+            player.crew -= amt;
+          } else {
+            alert('Insufficient crew');
+            return;
+          }
+          ship.updateCrewStats();
+          player.updateCrewStats();
+          updateHUD(player);
+        };
+        shipDiv.appendChild(crewBtn);
+
+        const cargoBtn = document.createElement('button');
+        cargoBtn.textContent = 'Transfer Cargo';
+        cargoBtn.onclick = () => {
+          const good = prompt('Good to transfer:');
+          if (!good) return;
+          const amt = parseInt(
+            prompt('Amount (positive from flagship to ship, negative for reverse):'),
+            10
+          );
+          if (isNaN(amt) || amt === 0) return;
+          const from = amt > 0 ? player : ship;
+          const to = amt > 0 ? ship : player;
+          const quantity = Math.abs(amt);
+          if ((from.cargo[good] || 0) < quantity) {
+            alert('Not enough goods');
+            return;
+          }
+          const used = Object.values(to.cargo).reduce((a, b) => a + b, 0);
+          if (amt > 0 && used + quantity > to.cargoCapacity) {
+            alert('No space');
+            return;
+          }
+          from.cargo[good] -= quantity;
+          if (from.cargo[good] <= 0) delete from.cargo[good];
+          to.cargo[good] = (to.cargo[good] || 0) + quantity;
+          updateHUD(player);
+        };
+        shipDiv.appendChild(cargoBtn);
+
+        const dismissBtn = document.createElement('button');
+        dismissBtn.textContent = 'Dismiss';
+        dismissBtn.onclick = () => {
+          if (confirm('Dismiss this ship?')) {
+            const index = player.fleet.indexOf(ship);
+            if (index !== -1) player.fleet.splice(index, 1);
+            closeFleetMenu();
+          }
+        };
+        shipDiv.appendChild(dismissBtn);
+      }
+      content.appendChild(shipDiv);
+    });
+  }
+
+  function renderRouteTab() {
+    content.innerHTML = '';
+    const shipSelect = document.createElement('select');
+    player.fleet.forEach((s, i) => {
+      const opt = document.createElement('option');
+      opt.value = i;
+      opt.textContent = s === player ? `${s.type} (Flagship)` : s.type;
+      shipSelect.appendChild(opt);
+    });
+    content.appendChild(shipSelect);
+
+    const info = document.createElement('div');
+    content.appendChild(info);
+
+    function refresh() {
+      const ship = player.fleet[parseInt(shipSelect.value)];
+      const route = getRoute(ship);
+      if (route) {
+        const cityNames = route.cities.map(c => c.name).join(' -> ');
+        info.textContent = `Route: ${cityNames} | Buy: ${route.buy.join(', ')} | Sell: ${route.sell.join(', ')}`;
+      } else {
+        info.textContent = 'No route';
+      }
     }
-    div.appendChild(shipDiv);
-  });
+
+    shipSelect.onchange = refresh;
+
+    const setBtn = document.createElement('button');
+    setBtn.textContent = 'Set Route';
+    setBtn.onclick = () => {
+      const cityNames = prompt('Comma-separated city names:');
+      if (!cityNames) return;
+      const names = cityNames
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+      const metaMap = bus.getCityMetadata?.() || new Map();
+      const allCities = Array.from(metaMap.keys());
+      const cities = names
+        .map(n => allCities.find(c => c.name === n))
+        .filter(Boolean);
+      if (!cities.length) {
+        alert('No valid cities');
+        return;
+      }
+      const buy =
+        prompt('Goods to buy (comma separated):')
+          ?.split(',')
+          .map(s => s.trim())
+          .filter(Boolean) || [];
+      const sell =
+        prompt('Goods to sell (comma separated):')
+          ?.split(',')
+          .map(s => s.trim())
+          .filter(Boolean) || [];
+      setRoute(player.fleet[parseInt(shipSelect.value)], {
+        cities,
+        buy,
+        sell,
+        index: 0
+      });
+      refresh();
+    };
+    content.appendChild(setBtn);
+
+    const clearBtn = document.createElement('button');
+    clearBtn.textContent = 'Clear Route';
+    clearBtn.onclick = () => {
+      const ship = player.fleet[parseInt(shipSelect.value)];
+      clearRoute(ship);
+      refresh();
+    };
+    content.appendChild(clearBtn);
+
+    refresh();
+  }
+
+  fleetBtn.onclick = renderFleetTab;
+  routeBtn.onclick = renderRouteTab;
+  renderFleetTab();
+
   const closeBtn = document.createElement('button');
   closeBtn.textContent = 'Close';
   closeBtn.onclick = closeFleetMenu;


### PR DESCRIPTION
## Summary
- Introduce `tradeRoutes` module to define ship trade routes, serialize them, and automate buying and selling at ports
- Add Trade Route tab to fleet UI to assign routes and goods for individual ships
- Enable fleet controller and ships to navigate route waypoints and execute automated trades, with routes saved/loaded in game state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc72496d1c832fa3b8a630b589b475