### PR TITLE
Anchor seed controls to bottom-right via CSS

### DIFF
--- a/pirates/index.html
+++ b/pirates/index.html
@@ -129,6 +129,15 @@
       height: 150px;
       transform: rotateX(60deg) rotateZ(45deg);
     }
+
+    .seed-controls {
+      position: absolute;
+      bottom: 10px;
+      right: 10px;
+      background: rgba(0,0,0,0.7);
+      color: #fff;
+      padding: 5px;
+    }
   </style>
 </head>
 <body>
@@ -148,7 +157,7 @@
     <div id="commandKeys"></div>
   </div>
   <!-- Seed controls to allow starting world with a specific seed -->
-  <div id="seedControls" style="position:absolute; top:590px; right:10px; background:rgba(0,0,0,0.7); color:#fff; padding:5px;">
+  <div id="seedControls" class="seed-controls">
     Seed: <input id="seedInput" type="number" style="width:80px;">
     Octaves: <input id="octavesInput" type="number" value="4" style="width:40px;">
     Temp: <input id="tempInput" type="number" step="0.1" value="1" style="width:40px;">


### PR DESCRIPTION
## Summary
- Move seed control styles into a `.seed-controls` CSS class for consistent styling
- Position seed controls at the bottom-right of the viewport to maintain alignment on resize

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd0677588c832f96d68a593ead64db